### PR TITLE
Transfer Ownership (TO1) implementation in CBOR

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 file(GLOB LIB_SOURCES *.c)
 file(GLOB LIB_DI_SOURCES prot/di/*.c)
-#file(GLOB LIB_TO1_SOURCES prot/to1/*.c)
+file(GLOB LIB_TO1_SOURCES prot/to1/*.c)
 #file(GLOB LIB_TO2_SOURCES prot/to2/*.c)
 
 client_sdk_include_directories(
@@ -16,7 +16,7 @@ client_sdk_include_directories(
 client_sdk_sources(
   ${LIB_SOURCES}
   ${LIB_DI_SOURCES}
-  #${LIB_TO1_SOURCES}
+  ${LIB_TO1_SOURCES}
   #${LIB_TO2_SOURCES}
   )
 

--- a/lib/include/sdoprot.h
+++ b/lib/include/sdoprot.h
@@ -183,6 +183,7 @@ typedef struct sdo_prot_s {
 	uint32_t port1;
 	char *dns1;
 	int key_encoding;
+	fdo_rvto2addr_t *rvto2addr;
 	sdo_public_key_t *new_pk;
 	sdo_dev_cred_t *dev_cred;
 	sdo_public_key_t *mfg_public_key; // TO2.bo.oh.pk & DI.oh.ok
@@ -258,7 +259,7 @@ bool sdo_process_states(sdo_prot_t *ps);
 bool sdo_check_to2_round_trips(sdo_prot_t *ps);
 
 void sdo_send_error_message(sdow_t *sdow, int ecode, int msgnum,
-					char *emsg);
+					char *emsg, size_t errmsg_sz);
 void sdo_receive_error_message(sdor_t *sdor, int *ecode, int *msgnum,
 			       char *emsg, int emsg_sz);
 bool sdo_prot_rcv_msg(sdor_t *sdor, sdow_t *sdow, char *prot_name, int *statep);

--- a/lib/include/sdotypes.h
+++ b/lib/include/sdotypes.h
@@ -115,7 +115,8 @@ bool sdo_string_read(sdor_t *sdor, sdo_string_t *b);
 #define SDO_GID_BYTES (128 / 8)
 #define SDO_NONCE_BYTES (128 / 8)
 #define SDO_NONCE_FIELD_BYTES 32
-#define SDO_UEID_BYTES (128 / 8) + 1
+// EAT-UEID is of length 17 (EAT-RAND(1) + EAT-GUID(16))
+#define SDO_UEID_BYTES (1 + SDO_GUID_BYTES)
 #define SDO_MSG_PRIFIX_LEN 48
 #define SDO_MSG_UUID_LEN 16
 #define SDO_APP_ID_BYTES 16
@@ -511,7 +512,7 @@ typedef struct sdo_rendezvous_list_s {
 	sdo_rendezvous_directive_t *rv_directives;
 } sdo_rendezvous_list_t;
 
-bool sdo_rendezvous_directive_add(sdo_rendezvous_list_t *list,
+int sdo_rendezvous_directive_add(sdo_rendezvous_list_t *list,
 	sdo_rendezvous_directive_t *directive);
 sdo_rendezvous_directive_t *sdo_rendezvous_directive_get(
 	sdo_rendezvous_list_t *list, int num);

--- a/lib/include/sdotypes.h
+++ b/lib/include/sdotypes.h
@@ -226,13 +226,14 @@ void sdo_app_id_write(sdow_t *sdow);
 #define SDO_CRYPTO_PUB_KEY_ALGO_EPID_1_1 91
 #define SDO_CRYPTO_PUB_KEY_ALGO_EPID_2_0 92
 
-// COSECompatibleSignatureTypes
+// 3.3.5 COSECompatibleSignatureTypes
 #define FDO_CRYPTO_SIG_TYPE_ECSDAp256 -7
 #define FDO_CRYPTO_SIG_TYPE_ECSDAp384 -35
 #define FDO_CRYPTO_SIG_TYPE_ECSDAp512 -36
 
 #define FDO_COSE_ALG_KEY 1
 
+// Appendix E
 #define FDO_EATFDO -17760707
 #define FDO_EAT_MAROE_PREFIX_KEY -17760708
 #define FDO_EAT_EUPHNONCE_KEY -17760709

--- a/lib/m-string.c
+++ b/lib/m-string.c
@@ -133,22 +133,20 @@ int ps_get_m_string(sdo_prot_t *ps)
 		goto err;
 	}
 
-	if (0 != read_buffer_from_file(TPM_DEVICE_CSR, csr->bytes,
-				       csr->byte_sz)) {
+	ret = read_buffer_from_file(TPM_DEVICE_CSR, csr->bytes,
+				       csr->byte_sz);
+	if (0 != ret) {
 		LOG(LOG_ERROR, "Failed to read %s file!\n", TPM_DEVICE_CSR);
 		goto err;
 	}
 
-	// TO-DO - Update the TPM script to:
-	// 1. Not store serial and model number in the file.
-	// 2. Store only the CSR in DER format.
-	// This does not work without the above changes.
-#endif
+#else
 	ret = sdo_get_device_csr(&csr);
 	if (0 != ret) {
 		LOG(LOG_ERROR, "Unable to get device CSR\n");
 		goto err;
 	}
+#endif
 	if (!sdow_start_array(&ps->sdow, DEVICE_MFG_STRING_ARRAY_SZ))
 		goto err;
 	if (!sdow_signed_int(&ps->sdow, key_id))

--- a/lib/prot/to1/msg30.c
+++ b/lib/prot/to1/msg30.c
@@ -8,46 +8,51 @@
  * \brief Implementation of TO1 protocol message 30.
  */
 
+#include "util.h"
 #include "sdoprot.h"
 
 /**
- * msg30() - TO1.HelloSDO
+ * msg30() - TO1.HelloRV, Type 30
  * The device is powered ON again in customer premises and the process of
  * finding rightful owner begins with this message. The device will
  * prepare itself to talk to Rendezvous(RV) Server and establish the trust
  * to get the credentials of next owner
  *
- * --- Message Format Begins ---
- *  {
- *      "g2": GUID,   # Device GUID, received and stored during DI
- *      "eA": Sig_info # eA: Device Signature information
- *  }
- * --- Message Format Ends ---
- *
- * --- eA for EPID ---
- * Value = 92 (EPID2.0): 128bit number
- *
- * --- eA format for ECDSA ---
- * Value = 13 (ECDSA256): 128bit number
- * Value = 14 (ECDSA384): 128bit number
+ * [
+ *   Guid,
+ *   eASigInfo
+ * ]
  */
 int32_t msg30(sdo_prot_t *ps)
 {
+	LOG(LOG_DEBUG, "TO1.HelloRV started\n");
 	sdow_next_block(&ps->sdow, SDO_TO1_TYPE_HELLO_SDO);
-	sdow_begin_object(&ps->sdow);
+	if (!sdow_start_array(&ps->sdow, 2)) {
+		LOG(LOG_ERROR, "TO1.HelloRV: Failed to start array\n");
+		return false;
+	}
 
 	/* Write GUID received during DI */
-	sdo_write_tag(&ps->sdow, "g2");
-	sdo_byte_array_write_chars(&ps->sdow, ps->dev_cred->owner_blk->guid);
+	if (!sdow_byte_string(&ps->sdow, ps->dev_cred->owner_blk->guid->bytes,
+		ps->dev_cred->owner_blk->guid->byte_sz)) {
+		LOG(LOG_ERROR, "TO1.HelloRV: Failed to write Guid\n");
+		return false;
+	}
 
 	/* Write the siginfo for RV to use and prepare next msg */
-	sdo_write_tag(&ps->sdow, "eA");
-	sdo_gid_write(&ps->sdow);
+	if (!sdo_siginfo_write(&ps->sdow)) {
+		LOG(LOG_ERROR, "TO1.HelloRV: Failed to write eASigInfo\n");
+		return false;
+	}
 
-	sdow_end_object(&ps->sdow);
+	if (!sdow_end_array(&ps->sdow)) {
+		LOG(LOG_ERROR, "TO1.HelloRV: Failed to end array\n");
+		return false;
+	}
 
 	/* Move to next state (msg31) */
 	ps->state = SDO_STATE_TO1_RCV_HELLO_SDOACK;
+	LOG(LOG_DEBUG, "TO1.HelloRV completed successfully\n");
 
 	return 0;
 }

--- a/lib/prot/to1/msg31.c
+++ b/lib/prot/to1/msg31.c
@@ -12,37 +12,20 @@
 #include "sdoprot.h"
 
 /**
- * msg31() - TO1.HelloSDOAck
+ * msg31() - TO1.HelloRVAck, Type 31
  * The device receives information which it needs to use to prove to
  * Rendezvous(RV) Server, that it is the device which it claims it to
  * be.
  *
- * --- Message Format Begins ---
- * {
- *      "n4": Nonce,  # Calcuate sign on Nonce for sigature freshness
- *      "eB": Sig_info # Information to use for signing
- * }
- * --- Message Format Ends
- *
- * --- eB for EPID 2.0 ---
- * {
- *     sig_rlSize: UInt16 # Size of data in sig_rl field
- * 	   sig_rl	: Signature Revocation List
- * 	   public_key_size: UInt16 Size of data in public_key field
- * 	   public_key: Group public key
- * }
- *
- * --- eB for ECDSA ---
- * {
- *     -- TODO --
- * }
- *
+ * [
+ *   Nonce4,
+ *   eBSigInfo
+ * ]
  */
 int32_t msg31(sdo_prot_t *ps)
 {
 	int ret = -1;
 	char prot[] = "SDOProtTO1";
-	char buf[DEBUGBUFSZ] = {0};
 
 	/* Read network data from internal buffer */
 	if (!sdo_prot_rcv_msg(&ps->sdor, &ps->sdow, prot, &ps->state)) {
@@ -50,43 +33,35 @@ int32_t msg31(sdo_prot_t *ps)
 		goto err;
 	}
 
-	if (!sdor_begin_object(&ps->sdor)) {
-		goto err;
-	}
+	LOG(LOG_DEBUG, "TO1.HelloRVAck started\n");
 
-	/* Read "n4" tag, and it's data */
-	if (!sdo_read_expected_tag(&ps->sdor, "n4")) {
+	if (!sdor_start_array(&ps->sdor)) {
+		LOG(LOG_ERROR, "TO1.HelloRVAck: Failed to start array\n");
 		goto err;
 	}
 
 	ps->n4 = sdo_byte_array_alloc(SDO_NONCE_BYTES);
-	if (!ps->n4 || !sdo_byte_array_read_chars(&ps->sdor, ps->n4)) {
+	if (!ps->n4 || !sdor_byte_string(&ps->sdor, ps->n4->bytes, ps->n4->byte_sz)) {
+		LOG(LOG_ERROR, "TO1.HelloRVAck: Failed to read Nonce4\n");
 		goto err;
 	}
 
-	LOG(LOG_DEBUG, "Received n4: %s\n",
-	    sdo_nonce_to_string(ps->n4->bytes, buf, sizeof buf) ? buf : "");
-
-	/* Read eB data: ECDSA */
-	if (!sdo_read_expected_tag(&ps->sdor, "eB")) {
+	if (!sdo_eb_read(&ps->sdor)) {
+		LOG(LOG_ERROR, "TO1.HelloRVAck: Failed to read eBSigInfo\n");
 		goto err;
 	}
 
-	/* Handle ECDSA cases */
-	if (0 != sdo_eb_read(&ps->sdor)) {
-		LOG(LOG_ERROR, "EB read in message 31 failed\n");
+	if (!sdor_end_array(&ps->sdor)) {
+		LOG(LOG_ERROR, "TO1.HelloRVAck: Failed to end array\n");
 		goto err;
 	}
-
-	if (!sdor_end_object(&ps->sdor)) {
-		goto err;
-	}
-
-	sdor_flush(&ps->sdor);
 
 	/* Updated state to move to msg32 */
 	ps->state = SDO_STATE_TO1_SND_PROVE_TO_SDO;
+	sdor_flush(&ps->sdor);
+	ps->sdor.have_block = false;
 	ret = 0;
+	LOG(LOG_DEBUG, "TO1.HelloRVAck completed successfully\n");
 
 err:
 	return ret;

--- a/lib/prot/to1/msg32.c
+++ b/lib/prot/to1/msg32.c
@@ -13,70 +13,101 @@
 #include "sdoCrypto.h"
 
 /**
- * msg32() - TO1.Prove_toSDO
+ * msg32() - TO1.ProveToRV, Type 32
  * The device responds with the data which potentially proves to RV that it is
  * the authorized device requesting the owner information
  *
- * --- Message Format Begins ---
- * {
- *      "bo": {
- *	    "ai": App_id,     # App_id of SDO
- *   	"n4": Nonce,     # Nonce which was received in msg31
- *      "g2": GUID,      # GUID sent to RV in msg30
- *      },
- *      "pk": Public_key, # EPID Public key if DA = epid, else PKNull
- *      "sg": Signature  # Signature calculated over nonce
- * }
- * --- Message Format Ends---
- *
+ * TO1.ProveToRV = EAToken
+ * EATPayloadBase //= (
+    EAT-NONCE: Nonce4
+ * )
  */
 int32_t msg32(sdo_prot_t *ps)
 {
 	int ret = -1;
-	sdo_sig_t sig = {0};
-	sdo_public_key_t *publickey;
+	fdo_eat_payload_base_map_t payloadbasemap;
+	sdo_byte_array_t *encoded_payloadbasemap = NULL;
 
-	LOG(LOG_DEBUG, "Starting SDO_STATE_TO1_SND_PROVE_TO_SDO\n");
+	LOG(LOG_DEBUG, "TO1.ProveToRV started\n");
 
+	// Allocate EAT object now. Initialize and fill the contents when needed to finally
+	// CBOR encode. Free once used in this method later.
+	fdo_eat_t *eat = fdo_eat_alloc();
+	if (!eat) {
+		LOG(LOG_ERROR, "TO1.ProveToRV: Failed to allocate for EAT\n");
+		goto err;
+	}
+
+#if defined(ECDSA256_DA)
+	eat->eat_ph->ph_sig_alg = FDO_CRYPTO_SIG_TYPE_ECSDAp256;
+#else
+	eat->eat_ph->ph_sig_alg = FDO_CRYPTO_SIG_TYPE_ECSDAp384;
+#endif
+
+	if (!ps->n4) {
+		LOG(LOG_ERROR, "TO1.ProveToRV: Nonce4 not found\n");
+		goto err;
+	}
+
+	// copy nonce4 and GUID into the struct
+	if (0 != memcpy_s(&payloadbasemap.eatnonce, SDO_NONCE_BYTES,
+		ps->n4->bytes, ps->n4->byte_sz)) {
+		LOG(LOG_ERROR, "TO1.ProveToRV: Failed to copy Nonce4\n");
+		goto err;
+	}
+	payloadbasemap.eatueid[0] = 1;
+	if (0 != memcpy_s(&payloadbasemap.eatueid[1], SDO_GUID_BYTES,
+		ps->dev_cred->owner_blk->guid->bytes, ps->dev_cred->owner_blk->guid->byte_sz)) {
+			LOG(LOG_ERROR, "TO1.ProveToRV: Failed to copy GUID\n");
+			goto err;
+	}
+	payloadbasemap.eatpayloads = NULL;
+
+	// Create the payload as CBOR map. Sign the encoded payload.
+	// Then, wrap the encoded payload a a bstr.
+	if (!fdo_eat_write_payloadbasemap(&ps->sdow, &payloadbasemap)) {
+		LOG(LOG_ERROR, "TO1.ProveToRV: Failed to write EATPayloadBaseMap\n");
+		goto err;
+	}
+	size_t payload_length = 0;
+	if (!sdow_encoded_length(&ps->sdow, &payload_length) || payload_length == 0) {
+		LOG(LOG_ERROR, "TO1.ProveToRV: Failed to read EATPayload length\n");
+		goto err;
+	}
+	ps->sdow.b.block_size = payload_length;
+	// Set the encoded payload into buffer
+	encoded_payloadbasemap =
+		sdo_byte_array_alloc_with_byte_array(ps->sdow.b.block, ps->sdow.b.block_size);
+	if (!encoded_payloadbasemap) {
+		LOG(LOG_ERROR, "TO1.ProveToRV: Failed to alloc for encoded EATPayload\n");
+		goto err;
+	}
+	eat->eat_payload = encoded_payloadbasemap;
+
+	// reset the SDOW block to prepare for the next encoding.
+	sdo_block_reset(&ps->sdow.b);
+	ps->sdow.b.block_size = CBOR_BUFFER_LENGTH;
+	if (!sdow_encoder_init(&ps->sdow)) {
+		LOG(LOG_ERROR, "TO1.ProveToRV: Failed to initilize SDOW encoder\n");
+		goto err;
+	}
+
+	// generate the signature on encoded payload
+	if (0 !=
+	    sdo_device_sign(eat->eat_payload->bytes, eat->eat_payload->byte_sz,
+			&eat->eat_signature)) {
+		LOG(LOG_ERROR, "TO1.ProveToRV: Failed to generate signature\n");
+		goto err;		
+	}
+
+	eat->eat_uph->eatmaroeprefix = NULL;
+	eat->eat_uph->euphnonce = NULL;
 	/* Start writing the block for msg31 */
 	sdow_next_block(&ps->sdow, SDO_TO1_TYPE_PROVE_TO_SDO);
 
-	/* Start Body/Begin Object "bo" tag */
-	publickey = NULL;
-
-	if (!sdo_begin_write_signature(&ps->sdow, &sig, publickey)) {
-		LOG(LOG_ERROR, "Failed in writing the signature\n");
-		goto err;
-	}
-
-	sdow_begin_object(&ps->sdow);
-
-	/* Write the "ai" tag */
-	sdo_write_tag(&ps->sdow, "ai");
-	sdo_app_id_write(&ps->sdow);
-
-	/* Write back the same nonce which was received in msg31 */
-	sdo_write_tag(&ps->sdow, "n4");
-	if (!ps->n4) {
-		LOG(LOG_ERROR, "ps->n4 is empty MSG#32\n");
-		goto err;
-	}
-
-	/* FIXME: Move to error handling. If TO1 restarts, we will leak memory
-	 */
-	sdo_byte_array_write_chars(&ps->sdow, ps->n4);
-	sdo_byte_array_free(ps->n4);
-	ps->n4 = NULL;
-
-	/* Write the GUID received during DI */
-	sdo_write_tag(&ps->sdow, "g2");
-	sdo_byte_array_write_chars(&ps->sdow, ps->dev_cred->owner_blk->guid);
-	/* TODO: Add support for epk defined in spec 0.8 */
-	sdow_end_object(&ps->sdow);
-
-	/* Fill in the pk and sg based on Device Attestation selected */
-	if (sdo_end_write_signature(&ps->sdow, &sig) != true) {
-		LOG(LOG_ERROR, "Failed in writing the signature\n");
+	// write the EAT structure
+	if (!fdo_eat_write(&ps->sdow, eat)) {
+		LOG(LOG_ERROR, "TO1.ProveToRV: Failed to write EAT\n");
 		goto err;
 	}
 
@@ -84,8 +115,12 @@ int32_t msg32(sdo_prot_t *ps)
 	ps->state = SDO_STATE_TO1_RCV_SDO_REDIRECT;
 	ret = 0;
 
-	LOG(LOG_DEBUG, "Complete SDO_STATE_TO1_SND_PROVE_TO_SDO\n");
+	LOG(LOG_DEBUG, "TO1.ProveToRV completed successfully\n");
 
 err:
+	if (eat)
+		fdo_eat_free(eat);
+	if (encoded_payloadbasemap)
+		sdo_byte_array_free(encoded_payloadbasemap);
 	return ret;
 }

--- a/lib/prot/to1/msg32.c
+++ b/lib/prot/to1/msg32.c
@@ -100,8 +100,6 @@ int32_t msg32(sdo_prot_t *ps)
 		goto err;		
 	}
 
-	eat->eat_uph->eatmaroeprefix = NULL;
-	eat->eat_uph->euphnonce = NULL;
 	/* Start writing the block for msg31 */
 	sdow_next_block(&ps->sdow, SDO_TO1_TYPE_PROVE_TO_SDO);
 
@@ -122,5 +120,7 @@ err:
 		fdo_eat_free(eat);
 	if (encoded_payloadbasemap)
 		sdo_byte_array_free(encoded_payloadbasemap);
+	if (ps->n4)
+		sdo_byte_array_free(ps->n4);
 	return ret;
 }

--- a/lib/prot/to1/msg33.c
+++ b/lib/prot/to1/msg33.c
@@ -72,7 +72,7 @@ int32_t msg33(sdo_prot_t *ps)
 
 	// initialize the parser once the buffer contains COSE payload to be decoded.
 	if (!sdor_parser_init(&ps->sdor)) {
-		LOG(LOG_ERROR, "TO1.RVRedirect: Failed to initilize SDOR parser\n");
+		LOG(LOG_ERROR, "TO1.RVRedirect: Failed to initialize SDOR parser\n");
 		return -1;
 	}
 

--- a/lib/sdo.c
+++ b/lib/sdo.c
@@ -137,7 +137,7 @@ static void sdo_protDIExit(app_data_t *app_data)
 }
 
 /**
- * Release memory allocated as a part of DI protocol.
+ * Release memory allocated as a part of TO1 protocol.
  *
  * @param app_data
  *        Pointer to the database holds all protocol state variables.
@@ -334,9 +334,11 @@ static sdo_sdk_status app_initialize(void)
 		return SDO_SUCCESS;
 	}
 
-	/* Build up a test service info list */
+// TO-DO: To be uncommented during TO2 implementation.
+/*
+	// Build up a test service info list
 	char *get_modules = NULL;
-
+	// TO-DO: To be uncommented during TO2 implementation.
 	g_sdo_data->service_info = sdo_service_info_alloc();
 
 	if (!g_sdo_data->service_info) {
@@ -382,7 +384,7 @@ static sdo_sdk_status app_initialize(void)
 					    "sdodev:modules", get_modules);
 		sdo_free(get_modules);
 	}
-
+*/
 	if (sdo_null_ipaddress(&g_sdo_data->prot.i1) == false) {
 		return SDO_ERROR;
 	}
@@ -962,90 +964,119 @@ static bool _STATE_TO1(void)
 		goto end;
 	}
 
-	sdo_prot_t *ps = &g_sdo_data->prot;
-
 	// check for rendezvous list
 	if (!g_sdo_data->devcred->owner_blk->rvlst ||
-	    g_sdo_data->devcred->owner_blk->rvlst->num_entries == 0) {
+	    g_sdo_data->devcred->owner_blk->rvlst->num_rv_directives == 0) {
 		LOG(LOG_ERROR, "Stored Rendezvous_list is empty!!\n");
 		ERROR();
 		goto end;
 	}
 
-	ps->rv_index = ps->rv_index + 1;
-	if (ps->rv_index > g_sdo_data->devcred->owner_blk->rvlst->num_entries)
-		ps->rv_index =
-		    ps->rv_index %
-		    g_sdo_data->devcred->owner_blk->rvlst->num_entries;
-	sdo_rendezvous_t *rv =
-	    g_sdo_data->devcred->owner_blk->rvlst->rv_entries;
-	for (int i = 1; i < ps->rv_index; i++)
-		rv = rv->next;
+	int port = 0;
+	sdo_ip_address_t *ip = NULL;
+	sdo_string_t *dns = NULL;
+	bool rvbypass = false;
+	sdo_rendezvous_directive_t *rv_directive =
+			g_sdo_data->devcred->owner_blk->rvlst->rv_directives;
+	
+	while (!ret && rv_directive) {
+		sdo_rendezvous_t *rv = rv_directive->rv_entries;
+		// reset for next use.
+		port = 0;
+		ip = NULL;
+		dns = NULL;
+		rvbypass = false;
+		while (rv) {
 
-	if (rv == NULL) {
-		ERROR();
-		goto end;
-	} else {
-		/* use the rendevous address from credential file ... pick
-		 * first/only entry in the list
-		 */
-		if (!rv->ip && !rv->dn) {
-			/* TODO put error cb	ERROR(); */
-			ret = true;
-			goto end;
-		}
-
-		/*if delay not specified in Rendezvous then 120s is default*/
-
-		// This should be checked against an 
-		if (rv->pr && *rv->pr == RVPROTHTTPS)
-			tls = true;
-	}
-
-	prot_ctx =
-	    sdo_prot_ctx_alloc(sdo_process_states, &g_sdo_data->prot, rv->ip,
-			       rv->dn ? rv->dn->bytes : NULL, *rv->po, tls);
-	if (prot_ctx == NULL) {
-		ERROR();
-		goto end;
-	}
-
-	if (sdo_prot_ctx_run(prot_ctx) != 0) {
-		LOG(LOG_ERROR, "TO1 failed.\n");
-		if (g_sdo_data->error_recovery) {
-			LOG(LOG_INFO, "Retrying,.....\n");
-			g_sdo_data->state_fn = &_STATE_TO1;
-			if (g_sdo_data->error_callback) {
-				status = g_sdo_data->error_callback(
-				    SDO_WARNING, SDO_TO1_ERROR);
-
-				if (status == SDO_ABORT) {
-					g_sdo_data->error_recovery = false;
-					g_sdo_data->recovery_enabled = false;
-					ERROR();
-					goto end;
-				}
+			if (rv->bypass) {
+				rvbypass = true;
+				break;
 			}
-			sdo_sleep(3);
-			/* Error recovery is enabled, so, it's not the final
-			 * status
-			 */
+			if (rv->owner_only) {
+				break;
+			}
+
+			if (rv->ip) {
+				ip = rv->ip;
+				rv = rv->next;
+				continue;
+			}
+			if (rv->dn) {
+				dns = rv->dn;
+				rv = rv->next;
+				continue;
+			}
+			if (rv->po) {
+				port = *rv->po;
+				rv = rv->next;
+				continue;
+			}
+			if (rv->pr && *rv->pr == RVPROTTLS) {
+				tls = true;
+			}
+			rv = rv->next;
+		}
+		if (rvbypass) {
+			// move to TO2 directly. However, update the flow to start from the next RV directive
+			// in case of failure with TO2. TO-DO.
+			g_sdo_data->state_fn = &_STATE_TO2;
 			goto end;
+		}
+		if ((!ip && !dns) || port == 0) {
+			// If any of the values are missing, check for the same in the next directives.
+			continue;
+		}
+		// Found the  needed entries of the current directive. Prepare to move to next.
+		rv_directive = rv_directive->next;
+	
+		prot_ctx =
+	    	sdo_prot_ctx_alloc(sdo_process_states, &g_sdo_data->prot, ip,
+		       dns ? dns->bytes : NULL, port, tls);
+		if (prot_ctx == NULL) {
+			ERROR();
+			goto end;
+		}
+
+		if (sdo_prot_ctx_run(prot_ctx) != 0) {
+			LOG(LOG_ERROR, "TO1 failed.\n");
+			if (g_sdo_data->error_recovery) {
+				LOG(LOG_INFO, "Retrying,.....\n");
+				g_sdo_data->state_fn = &_STATE_TO1;
+				if (g_sdo_data->error_callback) {
+					status = g_sdo_data->error_callback(
+			    		SDO_WARNING, SDO_TO1_ERROR);
+					if (status == SDO_ABORT) {
+						g_sdo_data->error_recovery = false;
+						g_sdo_data->recovery_enabled = false;
+						ERROR();
+						goto end;
+					}
+				}
+				sdo_sleep(3);
+				/* Error recovery is enabled, so, it's not the final
+		 		* status
+		 		*/
+			 	// clear contents for a fresh start.
+				sdo_protTO1Exit(g_sdo_data);
+			 	sdo_prot_ctx_free(prot_ctx);
+				continue;
+			} else {
+				ERROR()
+				sdo_sleep(g_sdo_data->delaysec + sdo_random() % 25);
+				if (g_sdo_data->error_callback)
+					status = g_sdo_data->error_callback(
+			    		SDO_ERROR, SDO_TO1_ERROR);
+				goto end;
+			}
 		} else {
-			ERROR()
-			sdo_sleep(g_sdo_data->delaysec + sdo_random() % 25);
-			if (g_sdo_data->error_callback)
-				status = g_sdo_data->error_callback(
-				    SDO_ERROR, SDO_TO1_ERROR);
+			LOG(LOG_DEBUG, "\n------------------------------------ TO1 Successful "
+		       "--------------------------------------\n");
+			ret = true;
+			g_sdo_data->state_fn = &_STATE_TO2;
 			goto end;
 		}
 	}
 
-	LOG(LOG_DEBUG, "\n------------------------------------ TO1 Successful "
-		       "--------------------------------------\n");
-
-	g_sdo_data->state_fn = &_STATE_TO2;
-	ret = true;
 end:
 	sdo_protTO1Exit(g_sdo_data);
 	sdo_prot_ctx_free(prot_ctx);

--- a/lib/sdocred.c
+++ b/lib/sdocred.c
@@ -376,7 +376,7 @@ sdo_ownership_voucher_t *sdo_ov_hdr_read(sdor_t *sdor, sdo_hash_t **hmac,
 	}
 
 	/* There must be at-least 1 valid rv entry, if not its a error-case */
-	if (ov->rvlst2->num_entries == 0) {
+	if (ov->rvlst2->num_rv_directives == 0) {
 		LOG(LOG_ERROR,
 		    "Invalid OVHeader: All rendezvous entries are invalid for the device!\n");
 		goto exit;

--- a/lib/sdoprotctx.c
+++ b/lib/sdoprotctx.c
@@ -296,6 +296,7 @@ int sdo_prot_ctx_run(sdo_prot_ctx_t *prot_ctx)
 
 		// clear the block contents in preparation for the next SDOW write operation
 		sdo_block_reset(&sdow->b);
+		sdow->b.block_size = CBOR_BUFFER_LENGTH;
 
 		/* ========================================================== */
 		/*  Receive response */

--- a/lib/sdotypes.c
+++ b/lib/sdotypes.c
@@ -2979,7 +2979,7 @@ void sdo_rendezvous_list_free(sdo_rendezvous_list_t *list)
  * @param rv - pointer to the RendezvousDirective to be added to the list
  * @return number of entries added if success else error code
  */
-bool sdo_rendezvous_directive_add(sdo_rendezvous_list_t *list,
+int sdo_rendezvous_directive_add(sdo_rendezvous_list_t *list,
 	sdo_rendezvous_directive_t *directive) {
 	if (list == NULL || directive == NULL)
 		return 0;

--- a/lib/sdotypes.c
+++ b/lib/sdotypes.c
@@ -1246,17 +1246,46 @@ char *sdo_guid_to_string(sdo_byte_array_t *g, char *buf, int buf_sz)
 #endif
 
 /**
- * Write the GID
- * @param sdow - pointer to the struct where the GID is written in JSON format
- * @return none
+ * Write the SigInfo of the form:
+ * SigInfo = [
+ *   sgType: DeviceSgType,
+ *   Info: bstr
+ * ]
+ * @param sdow - pointer to the struct where the GID is to be written.
+ * @return true if write is successfull. false, otherwise.
  */
-void sdo_gid_write(sdow_t *sdow)
+bool sdo_siginfo_write(sdow_t *sdow)
 {
-	sdow_start_array(sdow, 2);
-	sdow_unsigned_int(sdow, SDO_PK_ALGO);
+	bool ret = false;
+	if (!sdow_start_array(sdow, 2)) {
+		LOG(LOG_ERROR, "SigInfo: Failed to start array\n");
+		return ret;
+	}
+	if (!sdow_unsigned_int(sdow, SDO_PK_ALGO)) {
+		LOG(LOG_ERROR, "SigInfo: Failed to write sgType\n");
+		return ret;
+	}
+
 	sdo_byte_array_t *empty_byte_array = sdo_byte_array_alloc(0);
-	sdow_byte_string(sdow, empty_byte_array->bytes, empty_byte_array->byte_sz);
-	sdow_end_array(sdow);
+	if (!empty_byte_array) {
+		LOG(LOG_ERROR, "SigInfo: Byte Array Alloc failed\n");
+		return false;
+	}
+
+	if (!sdow_byte_string(sdow, empty_byte_array->bytes, empty_byte_array->byte_sz)) {
+		LOG(LOG_ERROR, "SigInfo: Failed to write Info\n");
+		goto end;
+	}
+
+	if (!sdow_end_array(sdow)) {
+		LOG(LOG_ERROR, "SigInfo: Failed to end array\n");
+		goto end;
+	}
+	LOG(LOG_DEBUG, "eASigInfo write successfull\n");
+	ret = true;
+end:
+	sdo_byte_array_free(empty_byte_array);
+	return ret;
 }
 
 /**
@@ -1269,69 +1298,60 @@ sdo_cert_chain_t *sdo_cert_chain_alloc_empty(void)
 }
 
 /**
- * Read the Dummy EB i.e. [13, 0, ""] sent when ECDSA based device-attestation
- * is used.
- * @param sdor - pointe to the read EPID information in JSON format
- * @return true when successfully read, false in case of any issues.
+ * Do a dummy read for ECDSA
+ * @param sdor - pointer to the read location in CBOR format
+ * @return true on success and false on failure
  */
-bool sdo_ecdsa_dummyEBRead(sdor_t *sdor)
+bool sdo_eb_read(sdor_t *sdor)
 {
-	bool retval = false;
-	// TO-DO : Revisit signed vs unsigned int here.
+	bool ret = false;
 	int type = 0;
 	int exptype = 0;
-	uint8_t *buf;
-
-	/* "eB":[13,0,""] */
+	uint8_t *buf = {0};
 
 	if (!sdor)
 		goto end;
 
 	if (!sdor_start_array(sdor)) {
-		LOG(LOG_ERROR, "No begin Sequence\n");
+		LOG(LOG_ERROR, "SigInfo: Failed to start array\n");
 		goto end;
 	}
 
 	exptype = SDO_PK_ALGO;
 
-	sdor_signed_int(sdor, &type);
+	if (!sdor_signed_int(sdor, &type)) {
+		LOG(LOG_ERROR, "SigInfo: Failed to read sgType\n");
+		goto end;
+	}
+
 	if (type != exptype) {
 		LOG(LOG_ERROR,
-		    "Invalid ECDSA pubkey type, expected %d got %d\n", exptype,
+		    "SigInfo: Invalid sgType. Expected %d, Received %d\n", exptype,
 		    type);
 		goto end;
 	}
 
-	// read empty byte
-	// TO-DO : Read empty byte here.
-	buf = sdo_alloc(0);
-	if (!sdor_byte_string(sdor, buf, 0)) {
-		LOG(LOG_ERROR, "Invalid eBSigInfo!\n");
+	size_t info_length = 1;
+	if (!sdor_string_length(sdor, &info_length) || info_length != 0) {
+		LOG(LOG_ERROR,
+		    "SigInfo: Invalid Info length. Expected %d, Received %zu\n", 0,
+		    info_length);
 		goto end;
 	}
 
-	LOG(LOG_DEBUG, "Received eBSigInfo\n");
-
+	if (!sdor_byte_string(sdor, buf, info_length)) {
+		LOG(LOG_ERROR, "SigInfo: Failed to read Info\n");
+		goto end;
+	}
 
 	if (!sdor_end_array(sdor)) {
 		LOG(LOG_ERROR, "No End Array\n");
 		goto end;
 	}
-	retval = true;
-
+	LOG(LOG_DEBUG, "eBSigInfo read successfull\n");
+	ret = true;
 end:
-	return retval;
-}
-
-
-/**
- * Do a dummy read for ECDSA
- * @param sdor - pointer to the read location in JSON format
- * @return 0 on success and -1 on failure
- */
-int32_t sdo_eb_read(sdor_t *sdor)
-{
-	int32_t ret = (false == sdo_ecdsa_dummyEBRead(sdor)) ? -1 : 0;
+	sdo_free(buf);
 	return ret;
 }
 
@@ -2930,46 +2950,88 @@ sdo_rendezvous_list_t *sdo_rendezvous_list_alloc(void)
 void sdo_rendezvous_list_free(sdo_rendezvous_list_t *list)
 {
 	sdo_rendezvous_t *entry, *next;
+	sdo_rendezvous_directive_t *directive_entry, *directive_next;
 
 	if (list == NULL) {
 		return;
 	}
 
 	/* Delete all entries. */
-	next = entry = list->rv_entries;
-	while (entry) {
-		next = entry->next;
-		sdo_rendezvous_free(entry);
-		entry = next;
-	};
-
-	list->num_entries = 0;
+	directive_entry = directive_next = list->rv_directives;
+	while (directive_entry) {
+		next = entry = directive_entry->rv_entries;
+		while (entry) {
+			next = entry->next;
+			sdo_rendezvous_free(entry);
+			entry = next;
+		};
+		directive_next = directive_entry->next;
+		directive_entry = directive_next;
+	}
+	list->num_rv_directives = 0;
 	sdo_free(list);
 }
 
 /**
- * Add the rendzvous to the rendzvous list
- * @param list - pointer to the rendzvous list
- * @param rv - pointer to the rendezvous to be added to the list
+ * Add the RendezvousDirective to the RendezvousInfo list
+ * @param list - pointer to the RendezvousInfo list
+ * @param rv - pointer to the RendezvousDirective to be added to the list
  * @return number of entries added if success else error code
  */
-int sdo_rendezvous_list_add(sdo_rendezvous_list_t *list, sdo_rendezvous_t *rv)
+bool sdo_rendezvous_directive_add(sdo_rendezvous_list_t *list,
+	sdo_rendezvous_directive_t *directive) {
+	if (list == NULL || directive == NULL)
+		return 0;
+
+	LOG(LOG_DEBUG, "Adding directive to rvlst\n");
+
+	if (list->num_rv_directives == 0) {
+		// List empty, add the first entry
+		list->rv_directives = directive;
+		list->num_rv_directives++;
+	} else {
+		// already has entries, find the last entry
+		sdo_rendezvous_directive_t *entry_ptr, *prev_ptr;
+
+		entry_ptr = (sdo_rendezvous_directive_t *)list->rv_directives->next;
+		prev_ptr = list->rv_directives;
+		// Find the last entry
+		while (entry_ptr != NULL) {
+			prev_ptr = entry_ptr;
+			entry_ptr = (sdo_rendezvous_directive_t *)entry_ptr->next;
+		}
+		// Now the enty_ptr is pointing to the last entry
+		// Add the directive entry onto the end
+		prev_ptr->next = directive;
+		list->num_rv_directives++;
+	}
+	LOG(LOG_DEBUG, "Added directive to rvlst, %d entries\n", list->num_rv_directives);
+	return list->num_rv_directives;
+}
+
+/**
+ * Add the RendezvousInstr to the RendezvousDirective struct
+ * @param list - pointer to the RendezvousDirective list
+ * @param rv - pointer to the RendezvousInstr to be added to the list
+ * @return number of entries added if success else error code
+ */
+int sdo_rendezvous_list_add(sdo_rendezvous_directive_t *directives, sdo_rendezvous_t *rv)
 {
-	if (list == NULL || rv == NULL)
+	if (directives == NULL || rv == NULL)
 		return 0;
 
 	LOG(LOG_DEBUG, "Adding to rvlst\n");
 
-	if (list->num_entries == 0) {
+	if (directives->num_entries == 0) {
 		// List empty, add the first entry
-		list->rv_entries = rv;
-		list->num_entries++;
+		directives->rv_entries = rv;
+		directives->num_entries++;
 	} else {
 		// already has entries, find the last entry
 		sdo_rendezvous_t *entry_ptr, *prev_ptr;
 
-		entry_ptr = (sdo_rendezvous_t *)list->rv_entries->next;
-		prev_ptr = list->rv_entries;
+		entry_ptr = (sdo_rendezvous_t *)directives->rv_entries->next;
+		prev_ptr = directives->rv_entries;
 		// Find the last entry
 		while (entry_ptr != NULL) {
 			prev_ptr = entry_ptr;
@@ -2978,10 +3040,25 @@ int sdo_rendezvous_list_add(sdo_rendezvous_list_t *list, sdo_rendezvous_t *rv)
 		// Now the enty_ptr is pointing to the last entry
 		// Add the r entry onto the end
 		prev_ptr->next = rv;
-		list->num_entries++;
+		directives->num_entries++;
 	}
-	LOG(LOG_DEBUG, "Added to rvlst, %d entries\n", list->num_entries);
-	return list->num_entries;
+	LOG(LOG_DEBUG, "Added to rvlst, %d entries\n", directives->num_entries);
+	return directives->num_entries;
+}
+
+sdo_rendezvous_directive_t *sdo_rendezvous_directive_get(sdo_rendezvous_list_t *list, int num)
+{
+	int index;
+
+	if (list == NULL || list->rv_directives == NULL)
+		return NULL;
+
+	sdo_rendezvous_directive_t *entry_ptr = list->rv_directives;
+
+	for (index = 0; index < num; index++) {
+		entry_ptr = entry_ptr->next;
+	}
+	return entry_ptr;
 }
 
 /**
@@ -2991,14 +3068,14 @@ int sdo_rendezvous_list_add(sdo_rendezvous_list_t *list, sdo_rendezvous_t *rv)
  * @return sdo_rendezvous_t object.
  */
 
-sdo_rendezvous_t *sdo_rendezvous_list_get(sdo_rendezvous_list_t *list, int num)
+sdo_rendezvous_t *sdo_rendezvous_list_get(sdo_rendezvous_directive_t *directive, int num)
 {
 	int index;
 
-	if (list == NULL || list->rv_entries == NULL)
+	if (directive == NULL || directive->rv_entries == NULL)
 		return NULL;
 
-	sdo_rendezvous_t *entry_ptr = list->rv_entries;
+	sdo_rendezvous_t *entry_ptr = directive->rv_entries;
 
 	for (index = 0; index < num; index++) {
 		entry_ptr = entry_ptr->next;
@@ -3036,7 +3113,6 @@ int sdo_rendezvous_list_read(sdor_t *sdor, sdo_rendezvous_list_t *list)
 
 	LOG(LOG_DEBUG, "There are %zu RendezvousDirective(s) in the RendezvousInfo\n",
 		num_rv_directives);
-	list->num_rv_directives = num_rv_directives;
 
 	size_t rv_directive_index;
 
@@ -3059,6 +3135,13 @@ int sdo_rendezvous_list_read(sdor_t *sdor, sdo_rendezvous_list_t *list)
 			return false;
 		}
 
+		sdo_rendezvous_directive_t *rv_directive =
+			sdo_alloc(sizeof(sdo_rendezvous_directive_t));
+		if (!rv_directive) {
+			LOG(LOG_ERROR,
+		    "%s : RendezvousDirective alloc failed\n", __func__);
+			return false;			
+		}
 		size_t rv_instr_index;
 		for (rv_instr_index = 0; rv_instr_index < num_rv_instr; rv_instr_index++) {
 			// Read each rv entry and add to the rv list
@@ -3069,9 +3152,10 @@ int sdo_rendezvous_list_read(sdor_t *sdor, sdo_rendezvous_list_t *list)
 			LOG(LOG_DEBUG, "New rv allocated %p\n", (void *)rv_entry);
 
 			if (sdo_rendezvous_read(sdor, rv_entry))
-				sdo_rendezvous_list_add(list, rv_entry);
+				sdo_rendezvous_list_add(rv_directive, rv_entry);
 			else {
 				sdo_rendezvous_free(rv_entry);
+				// TO-DO: free directive here?
 				return false;
 			}
 		}
@@ -3080,6 +3164,7 @@ int sdo_rendezvous_list_read(sdor_t *sdor, sdo_rendezvous_list_t *list)
 		    	"%s : RendezvousDirective end array not found\n", __func__);
 		return false;
 		}
+		sdo_rendezvous_directive_add(list, rv_directive);
 	}
 	if (!sdor_end_array(sdor)) {
 		LOG(LOG_ERROR,
@@ -3111,10 +3196,14 @@ bool sdo_rendezvous_list_write(sdow_t *sdow, sdo_rendezvous_list_t *list)
 	int rv_directive_index;
 	for (rv_directive_index = 0; rv_directive_index < list->num_rv_directives;
 		rv_directive_index++) {
-		sdow_start_array(sdow, list->num_entries);
+		sdo_rendezvous_directive_t *directive = sdo_rendezvous_directive_get(list, rv_directive_index);
+		if (!directive) {
+			continue;
+		}
+		sdow_start_array(sdow, directive->num_entries);
 		int rv_instr_index;
-		for (rv_instr_index = 0; rv_instr_index < list->num_entries; rv_instr_index++) {
-			sdo_rendezvous_t *entry_Ptr = sdo_rendezvous_list_get(list, rv_instr_index);
+		for (rv_instr_index = 0; rv_instr_index < directive->num_entries; rv_instr_index++) {
+			sdo_rendezvous_t *entry_Ptr = sdo_rendezvous_list_get(directive, rv_instr_index);
 			if (entry_Ptr == NULL) {
 				continue;
 			}
@@ -3568,6 +3657,609 @@ bool sdo_encrypted_packet_windup(sdow_t *sdow, int type, sdo_iv_t *iv)
 //------------------------------------------------------------------------------
 // Write Signature Routines
 //
+
+/**
+ * Create an EAT object with memory allocated for Protected header,
+ * Unprotected header (EATMAROEPREFIX and EATNonce) and Payload.
+ * Signature is set to NULL.
+ */
+fdo_eat_t* fdo_eat_alloc(void) {
+
+	fdo_eat_t *eat = sdo_alloc(sizeof(fdo_eat_t));
+	if (!eat) {
+		LOG(LOG_ERROR, "Entity Attestation Token: Failed to alloc\n");
+		goto err;
+	}
+	eat->eat_ph = sdo_alloc(sizeof(fdo_eat_protected_header_t));
+	if (!eat->eat_ph) {
+		LOG(LOG_ERROR, "Entity Attestation Token: Failed to alloc Protected Header\n");
+		goto err;
+	}
+
+	eat->eat_uph = sdo_alloc(sizeof(fdo_eat_unprotected_header_t));
+	if (!eat->eat_uph) {
+		LOG(LOG_ERROR, "Entity Attestation Token: Failed to alloc Unprotected header\n");
+		goto err;
+	}
+	eat->eat_uph->eatmaroeprefix = sdo_byte_array_alloc(0);
+	if (!eat->eat_uph->eatmaroeprefix) {
+		LOG(LOG_ERROR, "Entity Attestation Token: Failed to alloc EATMAROEPrefix\n");
+		goto err;
+	}
+	eat->eat_uph->euphnonce = sdo_byte_array_alloc(SDO_NONCE_BYTES);
+	if (!eat->eat_uph->euphnonce) {
+		LOG(LOG_ERROR, "Entity Attestation Token: Failed to alloc EUPHNonce\n");
+		goto err;
+	}
+
+	eat->eat_payload = sdo_byte_array_alloc(sizeof(sdo_byte_array_t));
+	if (!eat->eat_payload) {
+		LOG(LOG_ERROR, "Entity Attestation Token: Failed to alloc EATPayload\n");
+		goto err;
+	}
+	// set the signature to NULL, since there's no use to allocate for it here.
+	eat->eat_signature = NULL;
+	return eat;
+err:
+	if (eat)
+		fdo_eat_free(eat);
+	return NULL;
+}
+
+void fdo_eat_free(fdo_eat_t *eat) {
+
+	if (eat->eat_ph) {
+		sdo_free(eat->eat_ph);
+	}
+	if (eat->eat_uph) {
+		sdo_byte_array_free(eat->eat_uph->eatmaroeprefix);
+		sdo_byte_array_free(eat->eat_uph->euphnonce);
+		sdo_free(eat->eat_uph);
+	}
+	if (eat->eat_payload) {
+		sdo_byte_array_free(eat->eat_payload);
+	}
+	if (eat->eat_signature) {
+		sdo_byte_array_free(eat->eat_signature);
+	}
+	sdo_free(eat);
+}
+
+/**
+ * Write an Entity Attestation Token by CBOR encoding the contents of the given EAT object.
+ * [
+ * protected header,
+ * unprotected header,
+ * payload,				// bstr
+ * signature			// bstr
+ * ]
+ * Return true, if write was a success. False otherwise.
+ */
+bool fdo_eat_write(sdow_t *sdow, fdo_eat_t *eat) {
+
+	if (!sdow_start_array(sdow, 4)) {
+		LOG(LOG_ERROR, "Entity Attestation Token: Failed to write start array\n");
+		return false;
+	}
+
+	if (!fdo_eat_write_protected_header(sdow, eat->eat_ph)) {
+		LOG(LOG_ERROR, "Entity Attestation Token: Failed to write protected header\n");
+		return false;
+	}
+
+	if (!fdo_eat_write_unprotected_header(sdow, eat->eat_uph)) {
+		LOG(LOG_ERROR, "Entity Attestation Token: Failed to write unprotected header\n");
+		return false;
+	}
+
+	if (!sdow_byte_string(sdow, eat->eat_payload->bytes, eat->eat_payload->byte_sz)) {
+		LOG(LOG_ERROR, "Entity Attestation Token: Failed to write payload\n");
+		return false;
+	}
+
+	if (!sdow_byte_string(sdow, eat->eat_signature->bytes, eat->eat_signature->byte_sz)) {
+		LOG(LOG_ERROR, "Entity Attestation Token: Failed to write signature\n");
+		return false;
+	}
+
+	if (!sdow_end_array(sdow)) {
+		LOG(LOG_ERROR, "Entity Attestation Token: Failed to write end array\n");
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Create EAT.EATProtectedHeaders (CBOR map) as CBOR bytes using the given contents.
+ * {
+ * keyAlg:<key-alg>
+ * }
+ * Return true, if write was a success. False otherwise.
+ */
+bool fdo_eat_write_protected_header(sdow_t *sdow, fdo_eat_protected_header_t *eat_ph) {
+
+	if (!sdow_start_map(sdow, 1)) {
+		LOG(LOG_ERROR,
+			"Entity Attestation Token Unprotected header: Failed to write start map\n");
+		return false;
+	}
+
+	if (!sdow_signed_int(sdow, FDO_COSE_ALG_KEY)) {
+		LOG(LOG_ERROR,
+			"Entity Attestation Token Unprotected header: Failed to write CoseAlg Key\n");
+		return false;
+	}
+
+	if (!sdow_signed_int(sdow, eat_ph->ph_sig_alg)) {
+		LOG(LOG_ERROR,
+			"Entity Attestation Token Unprotected header: Failed to write CoseAlg Value\n");
+		return false;
+	}
+
+	if (!sdow_end_map(sdow)) {
+		LOG(LOG_ERROR,
+			"Entity Attestation Token Unprotected header: Failed to write end map\n");
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Create EAT.EATUnprotectedHeaders (CBOR Map) as CBOR bytes using the given contents.
+ * {
+ * EATMAROEPrefix:<maroe-prefix>,	// optional element
+ * EUPHNonce:<nonce>				// optional element
+ * }
+ * Return true, if write was a success. False otherwise.
+ */
+bool fdo_eat_write_unprotected_header(sdow_t *sdow, fdo_eat_unprotected_header_t *eat_uph) {
+	// calculate the size of map.
+	int num_uph_elements = 0;
+	if (eat_uph->euphnonce) {
+		num_uph_elements++;
+	}
+	if (eat_uph->eatmaroeprefix) {
+		num_uph_elements++;
+	}
+	if (!sdow_start_map(sdow, num_uph_elements)) {
+		LOG(LOG_ERROR,
+			"Entity Attestation Token Unprotected header: Failed to write start map\n");
+		return false;
+	}
+
+	// Write EATMAROEPrefix only when its present.
+	if (eat_uph->eatmaroeprefix) {
+		if (!sdow_signed_int(sdow, FDO_EAT_MAROE_PREFIX_KEY)) {
+			LOG(LOG_ERROR,
+				"Entity Attestation Token Unprotected header: Failed to write EATMAROEPrefix Key\n");
+			return false;
+		}
+
+		if (!sdow_byte_string(sdow, eat_uph->eatmaroeprefix->bytes, eat_uph->eatmaroeprefix->byte_sz)) {
+			LOG(LOG_ERROR,
+				"Entity Attestation Token Unprotected header: Failed to write EATMAROEPrefix value\n");
+			return false;
+		}
+	}
+
+	// Write EUPHNonce only when its present.
+	if (eat_uph->euphnonce) {
+		if (!sdow_signed_int(sdow, FDO_EAT_EUPHNONCE_KEY)) {
+			LOG(LOG_ERROR,
+				"Entity Attestation Token Unprotected header: Failed to write EUPHNonce Key\n");
+			return false;
+		}
+
+		if (!sdow_byte_string(sdow, eat_uph->euphnonce->bytes, eat_uph->euphnonce->byte_sz)) {
+			LOG(LOG_ERROR,
+				"Entity Attestation Token Unprotected header: Failed to write EUPHNonce Value\n");
+			return false;
+		}
+	}
+
+	if (!sdow_end_map(sdow)) {
+		LOG(LOG_ERROR,
+			"Entity Attestation Token Unprotected header: Failed to write end map\n");
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Create EAT.EATPayloadBaseMap (CBOR Map) as CBOR bytes using the given contents.
+ * Before sending it across, the resulting encoded contents need to be CBOR encoded again
+ * into a bstr CBOR type.
+ * {
+ * EAT-UEID:<ueid>,
+ * EAT-NONCE:<nonce>,
+ * EAT-FDO:<EATPayloads> // optional element
+ * }
+ * Return true, if write was a success. False otherwise.
+ */
+bool fdo_eat_write_payloadbasemap(sdow_t *sdow, fdo_eat_payload_base_map_t *eat_payload) {
+	size_t num_payload_elements = 2;
+	if (eat_payload->eatpayloads) {
+		LOG(LOG_DEBUG,
+			"Entity Attestation Token PayloadBaseMap: EATPayload to be written\n");
+		num_payload_elements = 3;
+	}
+	if (!sdow_start_map(sdow, num_payload_elements)) {
+		LOG(LOG_ERROR,
+			"Entity Attestation Token PayloadBaseMap: Failed to write start map\n");
+		return false;
+	}
+
+	if (!sdow_signed_int(sdow, FDO_EATUEID_KEY)) {
+		LOG(LOG_ERROR,
+			"Entity Attestation Token PayloadBaseMap: Failed to write EAT-UEID Key\n");
+		return false;
+	}
+
+	if (!sdow_byte_string(sdow, eat_payload->eatueid, sizeof(eat_payload->eatueid))) {
+		LOG(LOG_ERROR,
+			"Entity Attestation Token PayloadBaseMap: Failed to write EAT-UEID value\n");
+		return false;
+	}
+
+	if (!sdow_signed_int(sdow, FDO_EATNONCE_KEY)) {
+		LOG(LOG_ERROR,
+			"Entity Attestation Token PayloadBaseMap: Failed to write EAT-NONCE Key\n");
+		return false;
+	}
+
+	if (!sdow_byte_string(sdow, eat_payload->eatnonce, sizeof(eat_payload->eatnonce))) {
+		LOG(LOG_ERROR,
+			"Entity Attestation Token PayloadBaseMap: Failed to write EAT-NONCE value\n");
+		return false;
+	}
+
+	if (num_payload_elements == 3) {
+		if (!sdow_signed_int(sdow, FDO_EATFDO)) {
+			LOG(LOG_ERROR,
+				"Entity Attestation Token PayloadBaseMap: Failed to write EAT-FDO Key\n");
+			return false;
+		}
+
+		if (!sdow_byte_string(sdow,
+				eat_payload->eatpayloads->bytes, eat_payload->eatpayloads->byte_sz)) {
+			LOG(LOG_ERROR,
+				"Entity Attestation Token PayloadBaseMap: Failed to write EAT-FDO value\n");
+			return false;
+		}
+	}
+
+	if (!sdow_end_map(sdow)) {
+		LOG(LOG_ERROR,
+			"Entity Attestation Token PayloadBaseMap: Failed to write end map\n");
+		return false;
+	}
+	return true;
+}
+
+bool fdo_cose_free(fdo_cose_t *cose) {
+	if (cose->cose_ph) {
+		cose->cose_ph->ph_sig_alg = 0;
+		sdo_free(cose->cose_ph);
+	}
+	if (cose->cose_payload) {
+		sdo_byte_array_free(cose->cose_payload);
+	}
+	if (cose->cose_signature) {
+		sdo_byte_array_free(cose->cose_signature);
+	}
+	sdo_free(cose);
+	return true;
+}
+
+/**
+ * Read CoseSignature.COSEProtectedHeaders (CBOR map) into the given fdo_cose_protected_header_t object.
+ * {
+ * keyAlg:<key-alg>
+ * }
+ * Return true, if read was a success. False otherwise.
+ */
+bool fdo_cose_read_protected_header(sdor_t *sdor, fdo_cose_protected_header_t *cose_ph) {
+	if (!sdor_start_map(sdor)) {
+		LOG(LOG_ERROR,
+			"COSE Protected header: Failed to read start map\n");
+		return false;
+	}
+
+	int cose_alg_key = 1;
+	if (!sdor_signed_int(sdor, &cose_alg_key) || cose_alg_key != 1) {
+		LOG(LOG_ERROR,
+			"COSE Protected header: Failed to read CoseAlg Key\n");
+		return false;
+	}
+
+	if (!sdor_signed_int(sdor, &cose_ph->ph_sig_alg)) {
+		LOG(LOG_ERROR,
+			"COSE Protected header: Failed to read CoseAlg Value\n");
+		return false;
+	}
+
+	if (!sdor_end_map(sdor)) {
+		LOG(LOG_ERROR,
+			"COSE Protected header: Failed to read end map\n");
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Read CoseSignature.COSEUnprotectedHeaders (Empty bstr).
+ * TO-DO : Update during TO2 if needed. With TO1, its an empty bstr.
+ * Return true, if read was a success. False otherwise.
+ */
+bool fdo_cose_read_unprotected_header(sdor_t *sdor) {
+	// No protected header elemnts to parse.
+	// expcting an empty bstr as COSE.UPH
+	// TO-DO : Update when PRI is updated to handle empty map.
+	bool ret = false;
+	size_t uph_length = 1;
+	if (!sdor_string_length(sdor, &uph_length) || uph_length != 0) {
+		LOG(LOG_ERROR, "COSE: Failed to read Unprotected header length\n");
+		return false;	
+	}
+	sdo_byte_array_t *empty_uph = sdo_byte_array_alloc(0);
+	if (!empty_uph) {
+		LOG(LOG_ERROR, "COSE: Failed to alloc Unprotected header\n");
+		goto end;
+	}
+	if (!sdor_byte_string(sdor, empty_uph->bytes, empty_uph->byte_sz)) {
+		LOG(LOG_ERROR, "COSE: Failed to read Unprotected header\n");
+		goto end;
+	}
+	ret = true;
+end:
+	sdo_byte_array_free(empty_uph);
+	return ret;
+}
+
+/**
+ * Read the given COSE into the fdo_cose_t parameter.
+ * The fdo_cose_t parameter should have memory pre-allocated.
+ * However, the internal elements must be un-allocated.
+ * The memory allocation for the same would be done in the method.
+ * [
+ * protected header,
+ * unprotected header,
+ * payload,				// bstr
+ * signature			// bstr
+ * ]
+ * Return true, if read was a success. False otherwise.
+ */
+bool fdo_cose_read(sdor_t *sdor, fdo_cose_t *cose) {
+
+	size_t num_cose_items = 4;
+	if (!sdor_array_length(sdor, &num_cose_items) || num_cose_items != 4) {
+		LOG(LOG_ERROR, "COSE: Failed to read/Invalid array length\n");
+		return false;		
+	}
+
+	if (!sdor_start_array(sdor)) {
+		LOG(LOG_ERROR, "COSE: Failed to read start array\n");
+		return false;
+	}
+
+	cose->cose_ph = sdo_alloc(sizeof(fdo_cose_protected_header_t));
+	if (!cose->cose_ph) {
+		LOG(LOG_ERROR, "COSE: Failed to alloc Protected Header\n");
+		goto end;
+	}
+	if (!fdo_cose_read_protected_header(sdor, cose->cose_ph)) {
+		LOG(LOG_ERROR, "COSE: Failed to read protected header\n");
+		goto end;
+	}
+
+	if (!fdo_cose_read_unprotected_header(sdor)) {
+		LOG(LOG_ERROR, "COSE: Failed to read unprotected header\n");
+		goto end;
+	}
+
+	size_t var_length = 0;
+	if (!sdor_string_length(sdor, &var_length) ||
+		var_length == 0) {
+		LOG(LOG_ERROR, "COSE: Failed to read payload length\n");
+		goto end;	
+	}
+	cose->cose_payload = sdo_byte_array_alloc(var_length);
+	if (!cose->cose_payload) {
+		LOG(LOG_ERROR, "COSE: Failed to alloc EATPayload\n");
+		goto end;
+	}
+	if (!sdor_byte_string(sdor, cose->cose_payload->bytes, cose->cose_payload->byte_sz)) {
+		LOG(LOG_ERROR, "COSE: Failed to read payload\n");
+		goto end;
+	}
+
+	var_length = 0;
+	if (!sdor_string_length(sdor, &var_length) ||
+		var_length == 0) {
+		LOG(LOG_ERROR, "COSE: Failed to read signature length\n");
+		goto end;	
+	}
+	cose->cose_signature = sdo_byte_array_alloc(var_length);
+	if (!cose->cose_signature) {
+		LOG(LOG_ERROR, "COSE: Failed to alloc Signature\n");
+		goto end;
+	}
+	if (!sdor_byte_string(sdor, cose->cose_signature->bytes, cose->cose_signature->byte_sz)) {
+		LOG(LOG_ERROR, "COSE: Failed to read signature\n");
+		goto end;
+	}
+
+	if (!sdor_end_array(sdor)) {
+		LOG(LOG_ERROR, "COSE: Failed to read end array\n");
+		goto end;
+	}
+	return true;
+
+end:
+	fdo_cose_free(cose);
+	return false;
+}
+
+void fdo_rvto2addr_entry_free(fdo_rvto2addr_entry_t *rvto2addr_entry) {
+	if (rvto2addr_entry->rvip)
+		sdo_byte_array_free(rvto2addr_entry->rvip);
+	if (rvto2addr_entry->rvdns)
+		sdo_string_free(rvto2addr_entry->rvdns);
+	sdo_free(rvto2addr_entry);	
+}
+
+void fdo_rvto2addr_free(fdo_rvto2addr_t *rvto2addr) {
+	if (rvto2addr) {
+		while (rvto2addr->rv_to2addr_entry) {
+			fdo_rvto2addr_entry_free(rvto2addr->rv_to2addr_entry);
+			rvto2addr->rv_to2addr_entry = (fdo_rvto2addr_entry_t *) rvto2addr->rv_to2addr_entry->next;
+		}
+		sdo_free(rvto2addr);
+	}
+}
+
+/**
+ * Read RVTO2AddrEntry into the given fdo_rvto2addr_entry_t object.
+ * Memory allocation for the internal elements of fdo_rvto2addr_entry_t object
+ * will be done in this method.
+ * However, the memory must be allocated for fdo_rvto2addr_entry_t object and
+ * given to this method.
+ * [
+ * RVIP,
+ * RVDNS,
+ * RVPort,
+ * RVProtocol
+ * ]
+ * Return true, if read was a success. False otherwise.
+ */
+bool fdo_rvto2addr_entry_read(sdor_t *sdor, fdo_rvto2addr_entry_t *rvto2addr_entry) {
+	size_t num_rvto2addr_entry_items = 0;
+	if (!sdor_array_length(sdor, &num_rvto2addr_entry_items) ||
+		num_rvto2addr_entry_items != 4) {
+		LOG(LOG_ERROR, "RVTO2AddrEntry: Failed to read/Invalid array length\n");
+		return false;
+	}
+
+	if (!sdor_start_array(sdor)) {
+		LOG(LOG_ERROR, "RVTO2AddrEntry: Failed to read start array\n");
+		return false;		
+	}
+	size_t rvip_length = 0;
+	if (!sdor_string_length(sdor, &rvip_length) || rvip_length == 0) {
+		LOG(LOG_ERROR, "RVTO2AddrEntry: Failed to read RVIP length\n");
+		return false;
+	}
+	rvto2addr_entry->rvip = sdo_byte_array_alloc(rvip_length);
+	if (!rvto2addr_entry->rvip) {
+		LOG(LOG_ERROR, "RVTO2AddrEntry: Failed to alloc RVIP\n");
+		return false;
+	}
+	if (!sdor_byte_string(sdor, rvto2addr_entry->rvip->bytes, rvto2addr_entry->rvip->byte_sz)) {
+		LOG(LOG_ERROR, "RVTO2AddrEntry: Failed to read RVIP\n");
+		return false;
+	}
+
+	size_t rvdns_length = 0;
+	if (!sdor_string_length(sdor, &rvdns_length) || rvdns_length == 0) {
+		LOG(LOG_ERROR, "RVTO2AddrEntry: Failed to read RVDNS length\n");
+		return false;
+	}
+	rvto2addr_entry->rvdns = sdo_string_alloc_size(rvdns_length);
+	if (!rvto2addr_entry->rvdns) {
+		LOG(LOG_ERROR, "RVTO2AddrEntry: Failed to alloc RVDNS\n");
+		return false;
+	}
+	
+	if (!sdor_text_string(sdor, rvto2addr_entry->rvdns->bytes, rvto2addr_entry->rvdns->byte_sz)) {
+		LOG(LOG_ERROR, "RVTO2AddrEntry: Failed to read RVDNS\n");
+		return false;
+	}
+
+	rvto2addr_entry->rvport = -1;
+	if (!sdor_signed_int(sdor, &rvto2addr_entry->rvport) ||
+		rvto2addr_entry->rvport == -1) {
+		LOG(LOG_ERROR, "RVTO2AddrEntry: Failed to read RVPort\n");
+		return false;
+	}
+
+	rvto2addr_entry->rvprotocol = -1;
+	if (!sdor_signed_int(sdor, &rvto2addr_entry->rvprotocol) ||
+		rvto2addr_entry->rvprotocol == -1) {
+		LOG(LOG_ERROR, "RVTO2AddrEntry: Failed to read RVProtocol\n");
+		return false;
+	}
+
+	if (!sdor_end_array(sdor)) {
+		LOG(LOG_ERROR, "RVTO2AddrEntry: Failed to read end array\n");
+		goto end;
+	}
+	return true;
+end:
+	fdo_rvto2addr_entry_free(rvto2addr_entry);
+	return false;
+}
+
+/**
+ * Read RVTO2Addr into the given fdo_rvto2addr_t object.
+ * Memory allocation for the internal elements of fdo_rvto2addr_t object
+ * will be done in this method.
+ * However, the memory must be allocated for fdo_rvto2addr_y_t object and
+ * given to this method.
+ * [
+ * +RVTO2AddrEntry 		// one or more RVTO2AddrEntry
+ * ]
+ * Return true, if read was a success. False otherwise.
+ */
+bool fdo_rvto2addr_read(sdor_t *sdor, fdo_rvto2addr_t *rvto2addr) {
+	size_t num_rvto2addr_items = 0;
+	if (!sdor_array_length(sdor, &num_rvto2addr_items) || num_rvto2addr_items == 0) {
+		LOG(LOG_ERROR, "RVTO2Addr: Failed to read/Invalid array length\n");
+		return false;
+	}
+
+	if (!sdor_start_array(sdor)) {
+		LOG(LOG_ERROR, "RVTO2Addr: Failed to read/Invalid array length\n");
+		return false;
+	}
+
+	LOG(LOG_DEBUG, "RVTO2Addr: There are %zu RVTO2AddrEntry(s)\n", num_rvto2addr_items);
+
+	rvto2addr->num_rvto2addr = num_rvto2addr_items;
+	rvto2addr->rv_to2addr_entry = sdo_alloc(sizeof(fdo_rvto2addr_entry_t));
+	if (!rvto2addr->rv_to2addr_entry) {
+		LOG(LOG_ERROR, "RVTO2Addr: Failed to alloc RVTO2AddrEntry\n");
+		return false;	
+	}
+	fdo_rvto2addr_entry_t *entry = rvto2addr->rv_to2addr_entry;
+	size_t i = 0;
+	for (;;) {
+
+		i++;
+		if (!fdo_rvto2addr_entry_read(sdor, entry)) {
+			LOG(LOG_ERROR, "RVTO2Addr: Failed to read RVTO2AddrEntry\n");
+			goto end;
+		}
+		if (i < num_rvto2addr_items) {
+			entry->next = sdo_alloc(sizeof(fdo_rvto2addr_entry_t));
+			if (!entry->next) {
+				LOG(LOG_ERROR, "RVTO2AddrEntry: Failed to read/Invalid array length\n");
+				goto end;
+			}
+			entry = (fdo_rvto2addr_entry_t *) entry->next;
+		} else {
+			break;
+		}
+	}
+	if (!sdor_end_array(sdor)) {
+		LOG(LOG_ERROR, "RVTO2Addr: Failed to read end array\n");
+		goto end;
+	}
+	return true;
+
+end:
+	fdo_rvto2addr_free(rvto2addr);
+	return false;
+}
 
 /**
  * Begin the signature


### PR DESCRIPTION
- Updating TO1 protocol messages (30-33) as per the FDO spec.
As a part of implementation, read and write operations for COSE and EAT
structures have been added, along with RVTO2Addr struct.
- RendezvousInfoList structure has been updated to contain RVDirectives
that inturn contain RVInstructions. This had been done so as to loop
through directives while trying for TO1.
- Fixing the DeviceMfgInfo flow for TPM, wherein, the TPM-generated CSR
was overwritten by file-system's EC-key generated CSR.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>