### PR TITLE
ServiceInfo implementation for sdo_sys module

### DIFF
--- a/cmake/extension.cmake
+++ b/cmake/extension.cmake
@@ -258,6 +258,9 @@ endif()
 
 if(${MODULES} STREQUAL true)
   client_sdk_compile_definitions(-DMODULES_ENABLED)
+  if (${BUILD} STREQUAL debug)
+    client_sdk_compile_definitions(-DDEBUG_LOGS)
+  endif()
 endif()
 
 if(${HTTPPROXY} STREQUAL true)

--- a/device_modules/sdo_sys/sdo_sys.c
+++ b/device_modules/sdo_sys/sdo_sys.c
@@ -12,230 +12,171 @@
 #include <unistd.h>
 #include "sdo_sys_utils.h"
 
-int sdo_sys(sdoSdkSiType type, int *count, sdoSdkSiKeyValue *sv)
+int sdo_sys(sdo_sdk_si_type type, sdor_t *sdor, char *module_message)
 {
-	int ret = 0;
-	static char *mod_data = NULL;
-	static char *mod_msg = NULL;
-	static char fileName[FILE_NAME_LEN];
-	int strcmp_maxver = 1;
-	int strcmp_minver = 1;
-	size_t sv_key_len = 0;
-	size_t sv_value_len = 0;
+	static char filename[FILE_NAME_LEN];
 	int strcmp_filedesc = 1;
 	int strcmp_write = 1;
 	int strcmp_exec = 1;
 	int result = SDO_SI_INTERNAL_ERROR;
-	uint8_t *binData = NULL;
-	int binLen = 0;
-	int converted = 0;
+	uint8_t *bin_data = NULL;
+	size_t bin_len = 0;
 
 	switch (type) {
-	case SDO_SI_START:
-		return SDO_SI_SUCCESS;
-	case SDO_SI_GET_DSI_COUNT:
-		if (count) {
-			*count = 1;
-			return SDO_SI_SUCCESS;
-		}
-		return SDO_SI_INTERNAL_ERROR;
+		case SDO_SI_START:
+		case SDO_SI_END:
+		case SDO_SI_FAILURE:
+			result = SDO_SI_SUCCESS;
+			goto end;
+		case SDO_SI_GET_DSI:
+			// this operation is not supported
+			result = SDO_SI_FAILURE;
+			goto end;
+		case SDO_SI_SET_OSI:
 
-	case SDO_SI_SET_PSI:
-		if (!sv || !sv->key || !sv->value)
-			return SDO_SI_INTERNAL_ERROR;
+		strcmp_s(module_message, SDO_MODULE_MSG_LEN, "filedesc",
+					&strcmp_filedesc);
+		strcmp_s(module_message, SDO_MODULE_MSG_LEN, "write", &strcmp_write);
+		strcmp_s(module_message, SDO_MODULE_MSG_LEN, "exec", &strcmp_exec);
 
-		sv_key_len = strnlen_s(sv->key, SDO_MAX_STR_SIZE);
-		sv_value_len = strnlen_s(sv->value, SDO_MAX_STR_SIZE);
-
-		if (sv_key_len == 0 || sv_value_len == 0 ||
-		    sv_key_len == SDO_MAX_STR_SIZE ||
-		    sv_value_len == SDO_MAX_STR_SIZE)
+		if (strcmp_filedesc != 0 && strcmp_exec != 0 &&
+					strcmp_write != 0) {
+#ifdef DEBUG_LOGS
+		printf("Invalid moduleMessage for sdo_sys "
+			"Module\n");
+#endif
 			return SDO_SI_CONTENT_ERROR;
-
-		strcmp_s(sv->key, sv_key_len, "maxver", &strcmp_maxver);
-		strcmp_s(sv->key, sv_key_len, "minver", &strcmp_minver);
-		if (strcmp_maxver == 0 || strcmp_minver == 0) {
-#ifdef DEBUG_LOGS
-			printf("sdo_sys-%s:%s\n", sv->key, sv->value);
-#endif
-			return SDO_SI_SUCCESS;
-		} else
-			return SDO_SI_CONTENT_ERROR;
-
-	case SDO_SI_GET_DSI:
-		if (sv) {
-			if (!count)
-				return SDO_SI_INTERNAL_ERROR;
-			if (*count == 0) {
-				// send active status -> "active":"1"
-				mod_msg = ModuleAlloc(MOD_MAX_MSG_LEN);
-				if (!mod_msg) {
-#ifdef DEBUG_LOGS
-					printf("ModuleAlloc failed!\n");
-#endif
-					goto end_psi;
-				}
-
-				ret = strcpy_s(mod_msg, MOD_MAX_MSG_LEN,
-					       MOD_ACTIVE_TAG);
-
-				if (ret != 0) {
-#ifdef DEBUG_LOGS
-					printf("Strcpy failed!\n");
-#endif
-					goto end_psi;
-				}
-
-				sv->key = mod_msg;
-#ifdef DEBUG_LOGS
-				printf("sv->key:%s\n", sv->key);
-#endif
-				mod_data =
-				    ModuleAlloc(strnlen_s(MOD_ACTIVE_STATUS,
-							  SDO_MAX_STR_SIZE) +
-						1); // +1 for NULL termination
-
-				if (!mod_data) {
-#ifdef DEBUG_LOGS
-					printf("ModuleAlloc failed!\n");
-#endif
-					goto end_psi;
-				}
-
-				if (0 != strcpy_s(mod_data,
-						  strnlen_s(MOD_ACTIVE_STATUS,
-							    SDO_MAX_STR_SIZE) +
-						      1,
-						  MOD_ACTIVE_STATUS)) {
-#ifdef DEBUG_LOGS
-					printf("Strcpy failed!\n");
-#endif
-					goto end_psi;
-				}
-
-				sv->value = mod_data;
-				result = SDO_SI_SUCCESS;
-				return result;
-
-			end_psi:
-				if (mod_data)
-					ModuleFree(mod_data);
-				if (mod_msg)
-					ModuleFree(mod_msg);
-				return result;
-			}
-			return SDO_SI_INTERNAL_ERROR;
 		}
-		return SDO_SI_INTERNAL_ERROR;
 
-	case SDO_SI_SET_OSI:
-		if (sv != NULL && sv->value != NULL && sv->key != NULL) {
-			sv_key_len = strnlen_s(sv->key, SDO_MAX_STR_SIZE);
-			sv_value_len = strnlen_s(sv->value, MOD_MAX_DATA_LEN);
+		if (strcmp_filedesc == 0) {
 
-			if (sv_key_len == 0 || sv_value_len == 0 ||
-			    sv_key_len == SDO_MAX_STR_SIZE ||
-			    sv_value_len == MOD_MAX_DATA_LEN)
-				return SDO_SI_CONTENT_ERROR;
-
-			strcmp_s(sv->key, sv_key_len, "filedesc",
-				 &strcmp_filedesc);
-			strcmp_s(sv->key, sv_key_len, "write", &strcmp_write);
-			strcmp_s(sv->key, sv_key_len, "exec", &strcmp_exec);
-
-			if (strcmp_filedesc != 0 && strcmp_exec != 0 &&
-			    strcmp_write != 0) {
+			if (!sdor_string_length(sdor, &bin_len)) {
 #ifdef DEBUG_LOGS
-				printf("Mod_Msg content is invalid for sdo_sys "
-				       "Module\n");
+				printf("Failed to read sdo_sys:filedesc length\n");
 #endif
-				return SDO_SI_CONTENT_ERROR;
+				goto end;			
 			}
 
-			binLen = b64To_bin_length(sv_value_len);
-
-			if (!binLen) {
-				goto end;
-			}
-
-			binData = ModuleAlloc(binLen * sizeof(uint8_t));
-			if (!binData) {
+			bin_data = ModuleAlloc(bin_len * sizeof(uint8_t));
+			if (!bin_data) {
 #ifdef DEBUG_LOGS
-				printf("ModuleAlloc failed\n");
+					printf("Failed to alloc for sdo_sys:filedesc\n");
 #endif
 				goto end;
 			}
 
-			if (memset_s(binData, binLen, 0) != 0) {
+			if (memset_s(bin_data, bin_len, 0) != 0) {
 #ifdef DEBUG_LOGS
-				printf("Memset failed!\n");
+				printf("Failed to clear sdo_sys:filedesc buffer\n");
 #endif
 				goto end;
 			}
 
-			converted =
-			    b64To_bin(sv_value_len, (uint8_t *)sv->value, 0,
-				       (size_t)binLen, binData, 0);
-			if (converted <= 0) {
+			if (!sdor_byte_string(sdor, bin_data, bin_len)) {
+#ifdef DEBUG_LOGS
+				printf("Failed to read sdo_sys:filedesc\n");
+#endif
 				goto end;
 			}
-			if (strcmp_filedesc == 0) {
-
-				if (strncpy_s(fileName, FILE_NAME_LEN,
-					      (char *)binData,
-					      converted) != 0) {
+		
+			if (0 != strncpy_s(filename, FILE_NAME_LEN,
+				(char *)bin_data, bin_len)) {
 #ifdef DEBUG_LOGS
-					printf("Strcpy failed!\n");
+				printf("Failed to copy sdo:sys:filedesc\n");
 #endif
-					goto end;
-				}
-
-				if (true ==
-				    delete_old_file((const char *)fileName)) {
-					result = SDO_SI_SUCCESS;
-				}
-
 				goto end;
-			} else if (strcmp_write == 0) {
+			}
 
-				if (!process_data(SDO_SYS_MOD_MSG_WRITE,
-						  binData, converted,
-						  fileName)) {
-#ifdef DEBUG_LOGS
-					printf("Process_data for write fail");
-#endif
-					goto end;
-				}
+			if (true ==
+				delete_old_file((const char *)filename)) {
 				result = SDO_SI_SUCCESS;
-				goto end;
-			} else {
-				if (!process_data(SDO_SYS_MOD_MSG_EXEC, binData,
-						  converted, fileName)) {
+			}
+
+			goto end;
+		}
+		else if (strcmp_write == 0) {
+
+			if (!sdor_string_length(sdor, &bin_len)) {
 #ifdef DEBUG_LOGS
-					printf("Process_data for exec fail");
+				printf("Failed to read sdo_sys:write length\n");
 #endif
-					goto end;
-				}
-				result = SDO_SI_SUCCESS;
+				goto end;			
+			}
+			
+			bin_data = ModuleAlloc(bin_len * sizeof(uint8_t));
+			if (!bin_data) {
+#ifdef DEBUG_LOGS
+					printf("Failed to alloc for sdo_sys:write\n");
+#endif
+				goto end;
+			}
+			if (memset_s(bin_data, bin_len, 0) != 0) {
+#ifdef DEBUG_LOGS
+				printf("Failed to clear sdo_sys:write buffer\n");
+#endif
 				goto end;
 			}
 
-		end:
-			if (binData)
-				ModuleFree(binData);
-			return result;
-		} else
-			return SDO_SI_INTERNAL_ERROR;
+			if (!sdor_byte_string(sdor, bin_data, bin_len)) {
+#ifdef DEBUG_LOGS
+				printf("Failed to read value for sdo_sys:write\n");
+#endif
+				goto end;
+			}
 
-	case SDO_SI_END:
-	case SDO_SI_FAILURE:
-		if (mod_msg)
-			ModuleFree(mod_msg);
-		if (mod_data)
-			ModuleFree(mod_data);
-		return SDO_SI_SUCCESS;
+			if (!process_data(SDO_SYS_MOD_MSG_WRITE, bin_data, bin_len, filename)) {
+#ifdef DEBUG_LOGS
+				printf("Failed to process value for sdo_sys:write");
+#endif
+				goto end;
+			}
+			result = SDO_SI_SUCCESS;
+			goto end;
+		}
+		else if (strcmp_exec == 0) {
 
-	default:
-		return SDO_SI_INTERNAL_ERROR;
+			if (!sdor_string_length(sdor, &bin_len)) {
+#ifdef DEBUG_LOGS
+				printf("Failed to read sdo_sys:exec length\n");
+#endif
+				goto end;			
+			}
+			
+			bin_data = ModuleAlloc(bin_len * sizeof(uint8_t));
+			if (!bin_data) {
+#ifdef DEBUG_LOGS
+					printf("Failed to alloc for sdo_sys:exec\n");
+#endif
+				goto end;
+			}
+			if (memset_s(bin_data, bin_len, 0) != 0) {
+#ifdef DEBUG_LOGS
+				printf("Failed to clear sdo_sys:exec buffer\n");
+#endif
+				goto end;
+			}
+
+			if (!sdor_byte_string(sdor, bin_data, bin_len)) {
+#ifdef DEBUG_LOGS
+				printf("Failed to read value for sdo_sys:exec\n");
+#endif
+				goto end;
+			}
+			if (!process_data(SDO_SYS_MOD_MSG_EXEC, bin_data, bin_len, NULL)) {
+#ifdef DEBUG_LOGS
+				printf("Failed to process sdo_sys:exec\n");
+#endif
+				goto end;
+			}
+			result = SDO_SI_SUCCESS;
+			goto end;
+		}
+
+		default:
+		result = SDO_SI_FAILURE;
 	}
+end:
+	if (bin_data)
+		ModuleFree(bin_data);
+	return result;
 }

--- a/device_modules/sdo_sys/sdo_sys.h
+++ b/device_modules/sdo_sys/sdo_sys.h
@@ -21,6 +21,24 @@
 
 #define MOD_MAX_DATA_LEN 1024
 
-int sdo_sys(sdoSdkSiType type, int *count, sdoSdkSiKeyValue *sv);
+/**
+ * The registered callback method for 'sdo_sys' Owner ServiceInfo module.
+ * 
+ * The input SDOR object holds the CBOR-encoded binary stream for the entire
+ * decrypted messsage of TO2.OwnerServiceInfo (Type 69), with the current position
+ * set to the ServiceInfoVal.
+ * The implementation 'MUST' directly parse and process ServiceInfoVal 'ONLY' 
+ * that's currently being pointed at, depending on the given module message, and return.
+ * 
+ * The input sdo_sdk_si_type can be used to do specific tasks depending on the use-case.
+ * However, it 'MUST' throw error on SDO_SI_GET_DSI.
+ * (The types could be updated in the future)
+ * 
+ * @param type - enum value to describe the operation to be done.
+ * @param sdor - SDOR object pointing to the ServiceInfoVal.
+ * @param module_message - moduleMessage that decides how ServiceInfoVal is processed.
+ * @return integer value SDO_SI_CONTENT_ERROR (0), SDO_SI_INTERNAL_ERROR (1), SDO_SI_SUCCESS (2).
+ */
+int sdo_sys(sdo_sdk_si_type type, sdor_t *sdor, char *module_message);
 
 #endif /* __SDO_SYS_H__ */

--- a/device_modules/sdo_sys/sdomodules.h
+++ b/device_modules/sdo_sys/sdomodules.h
@@ -6,6 +6,8 @@
 #ifndef __SDOMODULES_H__
 #define __SDOMODULES_H__
 
+#include "sdoblockio.h"
+
 /*
  * SDO module specific #defs (SvInfo)
  */
@@ -15,19 +17,19 @@
 #define SDO_MAX_MODULES 2
 #define SDO_MAX_STR_SIZE 512
 
+#define FDO_MODULE_MESSAGE_ACTIVE "active"
+
 /*==================================================================*/
 /* Service Info module registration functionality */
 
 // enum for ServiceInfo Types
 typedef enum {
   SDO_SI_START,
-  SDO_SI_GET_DSI_COUNT,
-  SDO_SI_SET_PSI,
   SDO_SI_GET_DSI,
   SDO_SI_SET_OSI,
   SDO_SI_END,
   SDO_SI_FAILURE
-} sdoSdkSiType;
+} sdo_sdk_si_type;
 
 // enum for SvInfo module CB return value
 enum { SDO_SI_CONTENT_ERROR, SDO_SI_INTERNAL_ERROR, SDO_SI_SUCCESS };
@@ -37,14 +39,17 @@ typedef struct sdoSdkSiKeyValue {
   char *value;
 } sdoSdkSiKeyValue;
 
+
 // callback to module
-typedef int (*sdoSdkServiceInfoCB)(sdoSdkSiType type, int *count,
-                                   sdoSdkSiKeyValue *si);
+typedef int (*sdo_sdk_device_service_infoCB)(sdo_sdk_si_type type, sdow_t *sdow);
+typedef int (*sdo_sdk_owner_service_infoCB)(sdo_sdk_si_type type,
+	sdor_t *sdor, char *module_message);
 
 /* module struct for modules */
 typedef struct {
-  char moduleName[SDO_MODULE_NAME_LEN];
-  sdoSdkServiceInfoCB serviceInfoCallback;
-} sdoSdkServiceInfoModule;
+	bool active;
+	char module_name[SDO_MODULE_NAME_LEN];
+	sdo_sdk_owner_service_infoCB service_info_callback;
+} sdo_sdk_service_info_module;
 
 #endif /* __SDOTYPES_H__ */

--- a/device_modules/sdo_sys/sys_utils_linux.c
+++ b/device_modules/sdo_sys/sys_utils_linux.c
@@ -38,13 +38,13 @@ static bool is_valid_filename(const char *fname)
 	// Now the array is as follow
 	//  "TEST FILENAME" "ext"
 
-	/* check the whitelisted extension type*/
+	// check the whitelisted extension type
 	substring++;
 	for (i = 0; i < (sizeof(whitelisted) / sizeof(whitelisted[0])); i++) {
 		strcmp_s(substring, strnlen_s(substring, 3), whitelisted[i],
 			 &strcmp_result);
 		if (!strcmp_result) {
-			/* extension matched  */
+			// extension matched
 			ret = true;
 			break;
 		}
@@ -55,7 +55,7 @@ static bool is_valid_filename(const char *fname)
 	ret = false;
 	t1 = filenme_woextension;
 
-	/* check for only alphanumeric no special char except _ */
+	// check for only alphanumeric no special char except _
 	while (*t1 != '\0') {
 		if ((*t1 >= 'a' && *t1 <= 'z') || (*t1 >= 'A' && *t1 <= 'Z') ||
 		    (*t1 >= '0' && *t1 <= '9') || (*t1 == '_')) {
@@ -69,6 +69,7 @@ static bool is_valid_filename(const char *fname)
 end:
 	return ret;
 }
+
 
 void *ModuleAlloc(int size)
 {
@@ -89,40 +90,49 @@ end:
 	return buf;
 }
 
-bool process_data(sdoSysModMsg type, uint8_t *data, uint32_t dataLen,
-		  char *File_name)
+bool process_data(sdoSysModMsg type, uint8_t *data, uint32_t data_len,
+		  char *file_name)
 {
 	int ret = false;
 	FILE *fp = NULL;
 	int error_code = 0;
-	char *new_filename = NULL;
-	int new_filename_sz = 0;
+	char *command = NULL;
+	static char exec_instructions[MOD_MAX_DATA_LEN];
+	static size_t exec_instructions_sz = 0;
+	const char exec_terminator = '\0';
+	const char *space_delimeter_str = " ";
+	char *exec_token, *exec_token_next;
+	int exec_token_index = 0;
+	size_t data_index = 0;
+	bool exec_received_complete = false;
 
-	if (!File_name || !data || !dataLen) {
+	if (!data || !data_len) {
 #ifdef DEBUG_LOGS
 		printf("NULL params in Process_data");
 #endif
-		goto end;
+		return false;
 	}
-#ifdef DEBUG_LOGS
-	printf("sdo_sys: Filename : %s :Size: %x\n", File_name, dataLen);
-#endif
 
 	// For writing to a file
 	if (type == SDO_SYS_MOD_MSG_WRITE) {
 
-		fp = fopen(File_name, "a");
+		fp = fopen(file_name, "a");
 		if (!fp) {
 #ifdef DEBUG_LOGS
-			printf("Could not open file(path): %s\n", File_name);
+			printf("sdo_sys write:Failed to open file(path): %s\n", file_name);
 #endif
-			goto end;
+			return false;
 		}
 
-		if (fwrite(data, sizeof(char), dataLen, fp) !=
-		    (size_t)dataLen) {
 #ifdef DEBUG_LOGS
-			printf("Error in fwrite");
+	printf("sdo_sys write : %"PRIu32 " bytes being written to the file %s\n",
+		data_len, file_name);
+#endif
+
+		if (fwrite(data, sizeof(char), data_len, fp) !=
+		    (size_t)data_len) {
+#ifdef DEBUG_LOGS
+			printf("sdo_sys write: Failed to write");
 #endif
 			goto end;
 		}
@@ -131,46 +141,115 @@ bool process_data(sdoSysModMsg type, uint8_t *data, uint32_t dataLen,
 	}
 
 	// For Exec call
+	// TO-DO : Update based on fdo_sys spec when PRI implements it.
 	if (type == SDO_SYS_MOD_MSG_EXEC) {
 
-		/*
-		 * Proper error check for system call
-		 * Allow only filename (no absolute path for secure env)
-		 */
-		if (is_valid_filename((const char *)File_name) == false) {
-			goto end;
+		// check if the received instruction is ending now with \0\0
+		if (exec_terminator == data[data_len - 1] &&
+			exec_terminator == data[data_len - 2]) {
+			exec_received_complete = true;
 		}
+		// append the exec instructions (whether partial or full)
+		// replace '\0' with ' '. this leaves two ' ' at the end
+		while (data_index < data_len) {
+			// -1 for final '\0'
+			if (exec_instructions_sz >= MOD_MAX_DATA_LEN - 1) {
+#ifdef DEBUG_LOGS
+				printf("sdo_sys exec: Received command is too large. Cannot process\n");
+#endif
+				goto end;
+			}
+			if (exec_terminator == data[data_index]) {
+				exec_instructions[exec_instructions_sz++] = space_delimeter_str[0];
+				data_index++;
+			} else {
+				exec_instructions[exec_instructions_sz++] = data[data_index++];
+			}
+		}
+		// set the 2nd last character to '\0'
+		exec_instructions[exec_instructions_sz - 2] = exec_terminator;
 
-		// Executable permission for current user for the file
-		if (chmod(File_name, 0700)) {
-			goto end;
-		}
-		new_filename_sz = strnlen_s(File_name, FILE_NAME_LEN) +
-				  3; // 3 for prefix "./"
-		if (new_filename_sz <= 3) {
-			goto end;
-		}
+		// if exec command is received completely, execute the instruction
+		// if not, continue and look for it in the next iteration
+		if (exec_received_complete) {
 
-		new_filename = (char *)malloc(new_filename_sz);
-		if (new_filename == NULL) {
-			goto end;
-		}
-		if (strncpy_s(new_filename, new_filename_sz, "./", 3)) {
-			goto end;
-		}
+			// copy the 'exec_instructions' array upto 'exec_instructions_sz'
+			// into 'command'. check if it is '\0' delimeted, and get the file name
+			command = (char *) ModuleAlloc(exec_instructions_sz);
+			if (command == NULL) {
+#ifdef DEBUG_LOGS
+				printf("sdo_sys exec : Failed to alloc for command\n");
+#endif
+				goto end;
+			}
 
-		if (strncat_s(new_filename, new_filename_sz, File_name,
-			      strnlen_s(File_name, FILE_NAME_LEN))) {
-			goto end;
-		}
-		error_code = system(new_filename);
-		if (error_code == -1)
-			goto end;
+			if (0 != strncpy_s(command, exec_instructions_sz,
+				&exec_instructions[0], exec_instructions_sz)) {
+				goto end;
+			}
 
+			// exec_token empties itself in the tokenization process and
+			// exec_token_next is provided for internal usage for strtok_s
+			exec_token = strtok_s(exec_instructions, &exec_instructions_sz,
+				space_delimeter_str, &exec_token_next);
+			while (exec_token) {
+				// 1st '\0' i.e 2nd token, gives the filename that will be executed.
+				if (exec_token_index == 1) {
+					// Proper error check for system call
+					// Allow only filename (no absolute path for secure env)
+					if (is_valid_filename((const char *) exec_token) == false) {
+#ifdef DEBUG_LOGS
+						printf("sdo_sys exec : Failed to get file name from command\n");
+#endif
+						goto end;
+					}
+					
+					// Executable permission for current user for the file
+					if (chmod(exec_token, 0700)) {
+#ifdef DEBUG_LOGS
+						printf("sdo_sys exec : Failed to set execute permission in %s\n",
+							file_name);
+#endif
+						goto end;
+					}
+				}
+				exec_token = strtok_s(NULL, &exec_instructions_sz,
+					space_delimeter_str, &exec_token_next);
+				exec_token_index++;
+			}
+
+#ifdef DEBUG_LOGS
+			printf("sdo_sys exec: Received command completely. Executing...\n");
+#endif
+			error_code = system(command);
+			if (error_code == -1) {
+#ifdef DEBUG_LOGS
+				printf("sdo_sys exec : Failed to execute command for file %s\n", file_name);
+#endif
+				goto end;
+			}
+
+		} else {
+#ifdef DEBUG_LOGS
+				printf("sdo_sys exec : Received command partially\n");
+#endif
+			// received partially. return now so that we don't clear exec_instructions
+			return true;
+		}
 		ret = true;
 	}
 
 end:
+	if (command)
+		ModuleFree(command);
+	// clear for next exec
+	if (0 != memset_s(&exec_instructions, sizeof(exec_instructions), 0)) {
+#ifdef DEBUG_LOGS
+		printf("sdo_sys exec : Failed to clear exec instructions\n");
+#endif
+	}
+	exec_instructions_sz = 0;
+
 	if (fp) {
 		if (fclose(fp) == EOF) {
 #ifdef DEBUG_LOGS
@@ -178,18 +257,15 @@ end:
 #endif
 		}
 	}
-	if (new_filename) {
-		free(new_filename);
-	}
 	return ret;
 }
 
-bool delete_old_file(const char *File_name)
+bool delete_old_file(const char *filename)
 {
 	FILE *file = NULL;
 	bool ret = false;
 
-	file = fopen(File_name, "w");
+	file = fopen(filename, "w");
 	if (file) {
 		if (!fclose(file)) {
 			ret = true;

--- a/include/sdomodules.h
+++ b/include/sdomodules.h
@@ -6,6 +6,8 @@
 #ifndef __SDOMODULES_H__
 #define __SDOMODULES_H__
 
+#include "sdoblockio.h"
+
 /*
  * SDO module specific #defs (Sv_info)
  */
@@ -19,14 +21,14 @@
 #define SDO_MAX_MODULES 1
 #endif
 
+#define FDO_MODULE_MESSAGE_ACTIVE "active"
+
 /*==================================================================*/
 /* Service Info module registration functionality */
 
 // enum for Service_info Types
 typedef enum {
 	SDO_SI_START,
-	SDO_SI_GET_DSI_COUNT,
-	SDO_SI_SET_PSI,
 	SDO_SI_GET_DSI,
 	SDO_SI_SET_OSI,
 	SDO_SI_END,
@@ -42,20 +44,24 @@ typedef struct sdo_sdk_si_key_value {
 } sdo_sdk_si_key_value;
 
 // callback to module
-typedef int (*sdo_sdk_service_infoCB)(sdo_sdk_si_type type, int *count,
-				      sdo_sdk_si_key_value *si);
+typedef int (*sdo_sdk_device_service_infoCB)(sdo_sdk_si_type type, sdow_t *sdow);
+typedef int (*sdo_sdk_owner_service_infoCB)(sdo_sdk_si_type type,
+	sdor_t *sdor, char *module_message);
 
 /* module struct for modules */
 typedef struct {
+	bool active;
 	char module_name[SDO_MODULE_NAME_LEN];
-	sdo_sdk_service_infoCB service_info_callback;
+	sdo_sdk_owner_service_infoCB service_info_callback;
 } sdo_sdk_service_info_module;
 
+extern int sdo_sys(sdo_sdk_si_type type, sdor_t *sdor, char *module_message);
+
 // Modules CB
+// TO-DO at a later time
 extern int devconfig(sdo_sdk_si_type type, int *count,
 		     sdo_sdk_si_key_value *si);
 extern int keypair(sdo_sdk_si_type type, int *count, sdo_sdk_si_key_value *si);
-extern int sdo_sys(sdo_sdk_si_type type, int *count, sdo_sdk_si_key_value *si);
 extern int pelionconfig(sdo_sdk_si_type type, int *count,
 			sdo_sdk_si_key_value *si);
 

--- a/lib/include/sdodeviceinfo.h
+++ b/lib/include/sdodeviceinfo.h
@@ -11,28 +11,40 @@
 #define ARCH "x86"
 #define OS_VERSION "Ubuntu-14"
 #define BIN_TYPE "x86"
+#define PATH_SEPARATOR "/"
 #define SEPARATOR ";"
+#define NEWLINE "\n"
+#define PROGENV "sh"
 
 #elif defined TARGET_OS_FREERTOS
 #define OS_NAME "FreeRTOS"
 #define ARCH "Esp"
 #define OS_VERSION "FreeRTOS-1.2"
 #define BIN_TYPE "ihex"
+#define PATH_SEPARATOR "/"
 #define SEPARATOR ";"
+#define NEWLINE "\n"
+#define PROGENV "sh"
 
 #elif defined TARGET_OS_MBEDOS
 #define OS_NAME "MbedOS"
 #define ARCH "CortexM"
 #define OS_VERSION "MbedOS-5.8"
 #define BIN_TYPE "arm"
+#define PATH_SEPARATOR "/"
 #define SEPARATOR ";"
+#define NEWLINE "\n"
+#define PROGENV "sh"
 
 #elif defined TARGET_OS_OPTEE
 #define OS_NAME "optee"
 #define ARCH "armv8"
 #define OS_VERSION "1.0" /* FIXME: */
 #define BIN_TYPE "arm"
+#define PATH_SEPARATOR "/"
 #define SEPARATOR ";"
+#define NEWLINE "\n"
+#define PROGENV "sh"
 #endif
 
 #endif

--- a/lib/include/sdotypes.h
+++ b/lib/include/sdotypes.h
@@ -505,13 +505,17 @@ bool fdo_rvto2addr_read(sdor_t *sdor, fdo_rvto2addr_t *rvto2addr);
 typedef struct sdo_key_value_s {
 	struct sdo_key_value_s *next;
 	sdo_string_t *key;
-	sdo_string_t *val;
+	sdo_string_t *str_val;
+	sdo_byte_array_t *bin_val;
+	int *int_val;
+	bool *bool_val;
 } sdo_key_value_t;
 
 sdo_key_value_t *sdo_kv_alloc(void);
 sdo_key_value_t *sdo_kv_alloc_with_array(const char *key,
 					 sdo_byte_array_t *val);
 sdo_key_value_t *sdo_kv_alloc_with_str(const char *key, const char *val);
+sdo_key_value_t *sdo_kv_alloc_key_only(const char *key);
 void sdo_kv_free(sdo_key_value_t *kv);
 void sdo_kv_write(sdow_t *sdow, sdo_key_value_t *kv);
 
@@ -605,7 +609,6 @@ typedef struct sdo_service_info_s {
 	sdo_key_value_t *kv;
 } sdo_service_info_t;
 
-bool fdo_serviceinfo_read(sdor_t *sdor);
 sdo_service_info_t *sdo_service_info_alloc(void);
 sdo_service_info_t *sdo_service_info_alloc_with(char *key, char *val);
 void sdo_service_info_free(sdo_service_info_t *si);
@@ -614,6 +617,12 @@ sdo_key_value_t **sdo_service_info_fetch(sdo_service_info_t *si,
 sdo_key_value_t **sdo_service_info_get(sdo_service_info_t *si, int key_num);
 bool sdo_service_info_add_kv_str(sdo_service_info_t *si, const char *key,
 				 const char *val);
+bool sdo_service_info_add_kv_bin(sdo_service_info_t *si, const char *key,
+				 const sdo_byte_array_t *val);
+bool sdo_service_info_add_kv_bool(sdo_service_info_t *si, const char *key,
+				 bool val);
+bool sdo_service_info_add_kv_int(sdo_service_info_t *si, const char *key,
+				 int val);
 bool sdo_service_info_add_kv(sdo_service_info_t *si, sdo_key_value_t *kv);
 bool sdo_signature_verification(sdo_byte_array_t *plain_text,
 				sdo_byte_array_t *sg, sdo_public_key_t *pk);
@@ -676,6 +685,11 @@ void sdo_sv_info_clear_module_psi_osi_index(
     sdo_sdk_service_info_module_list_t *module_list);
 bool sdo_construct_module_list(sdo_sdk_service_info_module_list_t *module_list,
 			       char **mod_name);
+
+bool fdo_serviceinfo_read(sdor_t *sdor, sdo_sdk_service_info_module_list_t *module_list,
+	int *cb_return_val);
+bool fdo_supply_serviceinfoval(sdor_t *sdor, char *module_name, char *module_message,
+	sdo_sdk_service_info_module_list_t *module_list, int *cb_return_val);
 
 bool sdo_compare_hashes(sdo_hash_t *hash1, sdo_hash_t *hash2);
 bool sdo_compare_byte_arrays(sdo_byte_array_t *ba1, sdo_byte_array_t *ba2);

--- a/lib/prot/to2/msg49.c
+++ b/lib/prot/to2/msg49.c
@@ -40,6 +40,7 @@ int32_t msg69(sdo_prot_t *ps)
 	sdo_encrypted_packet_t *pkt = NULL;
 	bool IsMoreServiceInfo;
 	bool isDone;
+	int module_ret_val = -1;
 
 	if (!sdo_check_to2_round_trips(ps)) {
 		goto err;
@@ -62,8 +63,6 @@ int32_t msg69(sdo_prot_t *ps)
 		LOG(LOG_ERROR, "TO2.OwnerServiceInfo: Failed to decrypt packet!\n");
 		goto err;
 	}
-
-	sdo_log_block(&ps->sdor.b);
 
 	if (!sdor_start_array(&ps->sdor)) {
 		LOG(LOG_ERROR, "TO2.OwnerServiceInfo: Failed to start array\n");
@@ -103,8 +102,8 @@ int32_t msg69(sdo_prot_t *ps)
 			goto err;
 		}
 	} else {
-		// Expecting ServiceInfo. TO-DO : Test ater
-		if (!fdo_serviceinfo_read(&ps->sdor)) {
+		// process the received ServiceInfo
+		if (!fdo_serviceinfo_read(&ps->sdor, ps->sv_info_mod_list_head, &module_ret_val)) {
 			LOG(LOG_ERROR, "TO2.OwnerServiceInfo: Failed to read ServiceInfo\n");
 			goto err;
 		}
@@ -114,17 +113,6 @@ int32_t msg69(sdo_prot_t *ps)
 		LOG(LOG_ERROR, "TO2.OwnerServiceInfo: Failed to end array\n");
 		goto err;
 	}
-/*
-		sdo_sdk_si_key_value osiKV;
-
-		if (!sdo_osi_parsing(&ps->sdor, ps->sv_info_mod_list_head,
-				     &osiKV, &mod_ret_val)) {
-			LOG(LOG_ERROR, "Sv_info: OSI did not "
-				       "finished "
-				       "gracefully!\n");
-			goto err;
-		}
-*/	
 
 	if (isDone) {
 		ps->state = SDO_STATE_TO2_SND_DONE;


### PR DESCRIPTION
- The current sdo_sys module and supporting methods have been updated to
work with CBOR. The module now takes in the CBOR stream directly,
processes the currently pointed-at ServiceInfoVal and returns, instead
of the older approach where key-value pairs were provided. This is
because only the ServiceInfo module knows how to parse the
ServiceInfoVal now, as opposed to being known Base-64 encoded value
previously. It also has been updated to being an Owner ServiceInfo
processing module only.
- The Device ServiceInfo only has the mandatory 'devmod' module added.
Support for multiple Device ServiceInfo modules will be added at a later
time.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>