### PR TITLE
Fix for issues in rvbypass and TO2 TLS flow

### DIFF
--- a/lib/include/sdotypes.h
+++ b/lib/include/sdotypes.h
@@ -95,11 +95,6 @@ typedef struct {
 	char *bytes;
 } sdo_string_t;
 
-// Generic boolean wrapper
-typedef struct {
-	bool *value;
-} sdo_bool_t;
-
 void sdo_string_init(sdo_string_t *b);
 sdo_string_t *sdo_string_alloc(void);
 sdo_string_t *sdo_string_alloc_size(size_t byte_sz);
@@ -548,22 +543,22 @@ void sdo_kv_write(sdow_t *sdow, sdo_key_value_t *kv);
 typedef struct sdo_rendezvous_s {
 	int num_params;
 	struct sdo_rendezvous_s *next;
-	sdo_bool_t *dev_only;
-	sdo_bool_t *owner_only;
+	bool *dev_only;
+	bool *owner_only;
 	sdo_ip_address_t *ip;
 	int *po;
 	int *pow;
 	sdo_string_t *dn;
 	sdo_hash_t *sch;
 	sdo_hash_t *cch;
-	sdo_bool_t *ui;
+	bool *ui;
 	sdo_string_t *ss;
 	sdo_string_t *pw;
 	sdo_string_t *wsp;
 	uint64_t *me;
 	uint64_t *pr;
 	uint64_t *delaysec;
-	sdo_bool_t *bypass;
+	bool *bypass;
 } sdo_rendezvous_t;
 
 sdo_rendezvous_t *sdo_rendezvous_alloc(void);

--- a/lib/sdo.c
+++ b/lib/sdo.c
@@ -1038,7 +1038,7 @@ static bool _STATE_TO1(void)
 				rv = rv->next;
 				continue;
 			}
-			if (rv->pr && *rv->pr == RVPROTHTTPS) {
+			if (rv->pr && (*rv->pr == RVPROTHTTPS || *rv->pr == RVPROTTLS)) {
 				tls = true;
 			}
 			rv = rv->next;
@@ -1177,7 +1177,7 @@ static bool _STATE_TO2(void)
 				port = *rv->po;
 				rv = rv->next;
 			}
-			if (rv->pr && *rv->pr == RVPROTHTTPS) {
+			if (rv->pr && (*rv->pr == RVPROTHTTPS || *rv->pr == RVPROTTLS)) {
 				tls = true;
 			}
 
@@ -1201,8 +1201,10 @@ static bool _STATE_TO2(void)
 			}
 			dns = g_sdo_data->current_rvto2addrentry->rvdns;
 			port = g_sdo_data->current_rvto2addrentry->rvport;
-			if (g_sdo_data->current_rvto2addrentry->rvprotocol == RVPROTHTTPS)
+			if (g_sdo_data->current_rvto2addrentry->rvprotocol == RVPROTHTTPS ||
+				g_sdo_data->current_rvto2addrentry->rvprotocol == RVPROTTLS) {
 				tls = true;
+			}
 			// prepare for next iteration beforehand
 			g_sdo_data->current_rvto2addrentry = g_sdo_data->current_rvto2addrentry->next;
 

--- a/lib/sdoprotctx.c
+++ b/lib/sdoprotctx.c
@@ -140,7 +140,8 @@ static bool sdo_prot_ctx_connect(sdo_prot_ctx_t *prot_ctx)
 		if (prot_ctx->host_dns) {
 			if (!resolve_dn(prot_ctx->host_dns,
 					&prot_ctx->resolved_ip,
-					prot_ctx->host_port, NULL,
+					prot_ctx->host_port,
+					(prot_ctx->tls ? &prot_ctx->ssl : NULL),
 					is_owner_proxy_defined())) {
 				ret = false;
 				break;
@@ -168,7 +169,7 @@ static bool sdo_prot_ctx_connect(sdo_prot_ctx_t *prot_ctx)
 		ATTRIBUTE_FALLTHROUGH;
 	case SDO_STATE_TO2_RCV_DONE_2: /* type 51 */
 		ret = connect_to_owner(prot_ctx->host_ip, prot_ctx->host_port,
-				       &prot_ctx->sock_hdl, NULL);
+				       &prot_ctx->sock_hdl, (prot_ctx->tls ? &prot_ctx->ssl : NULL));
 		break;
 	default:
 		LOG(LOG_ERROR, "%s reached unknown state\n", __func__);

--- a/lib/sdotypes.c
+++ b/lib/sdotypes.c
@@ -2490,12 +2490,12 @@ bool sdo_rendezvous_write(sdow_t *sdow, sdo_rendezvous_t *rv)
 	if (!sdow_start_array(sdow, rv->num_params))
 		return false;
 
-	if (rv->dev_only != NULL) {
+	if (rv->dev_only != NULL && *rv->dev_only == true) {
 		if (!sdow_signed_int(sdow, RVDEVONLY))
 			return false;
 	}
 
-	if (rv->owner_only != NULL) {
+	if (rv->owner_only != NULL && *rv->owner_only == true) {
 		if (!sdow_signed_int(sdow, RVOWNERONLY))
 			return false;
 	}
@@ -2538,7 +2538,7 @@ bool sdo_rendezvous_write(sdow_t *sdow, sdo_rendezvous_t *rv)
 
 	if (rv->ui != NULL) {
 		if (!sdow_signed_int(sdow, RVUSERINPUT) ||
-			!sdow_boolean(sdow, rv->ui->value))
+			!sdow_boolean(sdow, *rv->ui))
 			return false;
 	}
 
@@ -2572,7 +2572,7 @@ bool sdo_rendezvous_write(sdow_t *sdow, sdo_rendezvous_t *rv)
 			return false;
 	}
 
-	if (rv->bypass != NULL) {
+	if (rv->bypass != NULL && *rv->bypass == true) {
 		if (!sdow_signed_int(sdow, RVBYPASS))
 			return false;
 	}
@@ -2632,24 +2632,24 @@ bool sdo_rendezvous_read(sdor_t *sdor, sdo_rendezvous_t *rv)
 	// Parse the values found
 	switch (key) {
 	case RVDEVONLY:
-		rv->dev_only = sdo_alloc(sizeof(sdo_bool_t));
+		rv->dev_only = sdo_alloc(sizeof(bool));
 		if (!rv->dev_only) {
 			LOG(LOG_ERROR, "RVDEVONLY alloc failed\n");
 			ret = false;
 			break;
 		}
-		*rv->dev_only->value = true;
+		*rv->dev_only = true;
 		rv->num_params = 1;
 		break;
 
 	case RVOWNERONLY:
-		rv->owner_only = sdo_alloc(sizeof(sdo_bool_t));
+		rv->owner_only = sdo_alloc(sizeof(bool));
 		if (!rv->owner_only) {
 			LOG(LOG_ERROR, "RVOWNERONLY alloc failed\n");
 			ret = false;
 			break;
 		}
-		*rv->owner_only->value = true;
+		*rv->owner_only = true;
 		rv->num_params = 1;
 		break;
 
@@ -2773,13 +2773,13 @@ bool sdo_rendezvous_read(sdor_t *sdor, sdo_rendezvous_t *rv)
 
 	case RVUSERINPUT:
 
-		rv->ui = sdo_alloc(sizeof(sdo_bool_t));
+		rv->ui = sdo_alloc(sizeof(bool));
 		if (!rv->ui) {
 			LOG(LOG_ERROR, "RVUSERINPUT alloc failed\n");
 			ret = false;
 			break;
 		}
-		if (!sdor_boolean(sdor, rv->ui->value)) {
+		if (!sdor_boolean(sdor, rv->ui)) {
 			LOG(LOG_ERROR, "RVUSERINPUT read failed\n");
 			ret = false;
 		}
@@ -2875,13 +2875,13 @@ bool sdo_rendezvous_read(sdor_t *sdor, sdo_rendezvous_t *rv)
 
 	case RVBYPASS:
 
-		rv->bypass = sdo_alloc(sizeof(sdo_bool_t));
+		rv->bypass = sdo_alloc(sizeof(bool));
 		if (!rv->bypass) {
 			LOG(LOG_ERROR, "RVBYPASS alloc failed\n");
 			ret = false;
 			break;
 		}
-		*rv->bypass->value = true;
+		*rv->bypass = true;
 		rv->num_params = 1;
 		break;
 

--- a/network/network_if_linux.c
+++ b/network/network_if_linux.c
@@ -504,6 +504,9 @@ int32_t sdo_con_send_message(sdo_con_handle handle, uint32_t protocol_version,
 	rest->prot_ver = protocol_version;
 	rest->msg_type = message_type;
 	rest->content_length = length;
+	if (ssl) {
+		rest->tls = true;
+	}
 
 	if (!construct_rest_header(rest, rest_hdr, REST_MAX_MSGHDR_SIZE)) {
 		LOG(LOG_ERROR, "Error during constrcution of REST hdr!\n");

--- a/network/network_if_mbedos.c
+++ b/network/network_if_mbedos.c
@@ -362,6 +362,9 @@ int32_t sdo_con_send_message(sdo_con_handle handle, uint32_t protocol_version,
 	rest->prot_ver = protocol_version;
 	rest->msg_type = message_type;
 	rest->content_length = length;
+	if (ssl) {
+		rest->tls = true;
+	}
 
 	if (!construct_rest_header(rest, rest_hdr, REST_MAX_MSGHDR_SIZE)) {
 		LOG(LOG_ERROR, "Error during constrcution of REST hdr!\n");


### PR DESCRIPTION
Fixing a couple of issues with RVBypass and TO2 TLS:
- Fixing the RVBYPASS flow and updating the bool structure being used for
it. Subsequently, the bool wrapper struct has been removed.
- Fixing an issue where TO2 was not starting with TLS in RVBYPASS flow
when its been specified in RendezvousInfo by passing the TLS flag when
found. However, this fixes the TO2 TLS flow for RVTO2Addr as well.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>