### PR TITLE
Updates to serviceinfo and replace sdo_sys with fdo_sys

### DIFF
--- a/app/main.c
+++ b/app/main.c
@@ -109,9 +109,9 @@ static fdo_sdk_service_info_module *fdo_sv_info_modules_init(void)
 		return NULL;
 	}
 
-	/* module#1: sdo_sys */
+	/* module#1: fdo_sys */
 	if (strncpy_s(module_info[0].module_name, FDO_MODULE_NAME_LEN,
-		      "sdo_sys", FDO_MODULE_NAME_LEN) != 0) {
+		      "fdo_sys", FDO_MODULE_NAME_LEN) != 0) {
 		LOG(LOG_ERROR, "Strcpy failed");
 		free(module_info);
 		return NULL;

--- a/cmake/blob_path.cmake
+++ b/cmake/blob_path.cmake
@@ -21,6 +21,7 @@ if(TARGET_OS MATCHES linux)
     -DMANUFACTURER_IP=\"${BLOB_PATH}/data/manufacturer_ip.bin\"
     -DMANUFACTURER_DN=\"${BLOB_PATH}/data/manufacturer_dn.bin\"
     -DMANUFACTURER_PORT=\"${BLOB_PATH}/data/manufacturer_port.bin\"
+    -DMAX_SERVICEINFO_SIZE=\"${BLOB_PATH}/data/max_serviceinfo_size\"
     )
   if (${DA} MATCHES tpm)
     client_sdk_compile_definitions(
@@ -105,6 +106,7 @@ if(TARGET_OS MATCHES linux)
       -DMANUFACTURER_IP=\"${BLOB_PATH}/data/manufacturer_ip.bin\"
       -DMANUFACTURER_DN=\"${BLOB_PATH}/data/manufacturer_dn.bin\"
       -DMANUFACTURER_PORT=\"${BLOB_PATH}/data/manufacturer_port.bin\"
+      -DMAX_SERVICEINFO_SIZE=\"${BLOB_PATH}/data/max_serviceinfo_sz\"
       )
     if (${unit-test} MATCHES true)
       client_sdk_compile_definitions(
@@ -174,4 +176,4 @@ file(WRITE ${BLOB_PATH}/data/platform_aes_key.bin "")
 file(WRITE ${BLOB_PATH}/data/Normal.blob "")
 file(WRITE ${BLOB_PATH}/data/Secure.blob "")
 file(WRITE ${BLOB_PATH}/data/raw.blob "")
-
+file(WRITE ${BLOB_PATH}/data/max_serviceinfo_size "")

--- a/cmake/blob_path.cmake
+++ b/cmake/blob_path.cmake
@@ -21,7 +21,7 @@ if(TARGET_OS MATCHES linux)
     -DMANUFACTURER_IP=\"${BLOB_PATH}/data/manufacturer_ip.bin\"
     -DMANUFACTURER_DN=\"${BLOB_PATH}/data/manufacturer_dn.bin\"
     -DMANUFACTURER_PORT=\"${BLOB_PATH}/data/manufacturer_port.bin\"
-    -DMAX_SERVICEINFO_SIZE=\"${BLOB_PATH}/data/max_serviceinfo_size\"
+    -DMAX_SERVICEINFO_SZ_FILE=\"${BLOB_PATH}/data/max_serviceinfo_sz.bin\"
     )
   if (${DA} MATCHES tpm)
     client_sdk_compile_definitions(
@@ -106,7 +106,7 @@ if(TARGET_OS MATCHES linux)
       -DMANUFACTURER_IP=\"${BLOB_PATH}/data/manufacturer_ip.bin\"
       -DMANUFACTURER_DN=\"${BLOB_PATH}/data/manufacturer_dn.bin\"
       -DMANUFACTURER_PORT=\"${BLOB_PATH}/data/manufacturer_port.bin\"
-      -DMAX_SERVICEINFO_SIZE=\"${BLOB_PATH}/data/max_serviceinfo_sz\"
+      -DMAX_SERVICEINFO_SZ_FILE=\"${BLOB_PATH}/data/max_serviceinfo_sz.bin\"
       )
     if (${unit-test} MATCHES true)
       client_sdk_compile_definitions(
@@ -176,4 +176,4 @@ file(WRITE ${BLOB_PATH}/data/platform_aes_key.bin "")
 file(WRITE ${BLOB_PATH}/data/Normal.blob "")
 file(WRITE ${BLOB_PATH}/data/Secure.blob "")
 file(WRITE ${BLOB_PATH}/data/raw.blob "")
-file(WRITE ${BLOB_PATH}/data/max_serviceinfo_size "")
+file(WRITE ${BLOB_PATH}/data/max_serviceinfo_sz.bin "")

--- a/device_modules/fdo_sys/fdo_sys.c
+++ b/device_modules/fdo_sys/fdo_sys.c
@@ -20,8 +20,10 @@ int fdo_sys(fdo_sdk_si_type type, fdor_t *fdor, char *module_message)
 	int strcmp_exec = 1;
 	int result = FDO_SI_INTERNAL_ERROR;
 	uint8_t *bin_data = NULL;
-	size_t bin_len = 0, max_bin_len = MOD_MAX_EXEC_LEN,
-		exec_array_length = 0, exec_array_index = 0;
+	size_t bin_len = 0;
+	size_t max_bin_len = MOD_MAX_EXEC_LEN;
+	size_t exec_array_length = 0;
+	size_t exec_array_index = 0;
 	char exec_instructions[MOD_MAX_EXEC_ARG_LEN];
 	size_t exec_instructions_sz = 0;
 	char space_delimeter = ' ';

--- a/device_modules/fdo_sys/fdo_sys.h
+++ b/device_modules/fdo_sys/fdo_sys.h
@@ -19,7 +19,9 @@
 #define MOD_ACTIVE_TAG "active"
 #define MOD_ACTIVE_STATUS "1"
 
+// maximum length of exec command after combining all arguments of received exec array
 #define MOD_MAX_EXEC_LEN 1024
+// maximum length of the individual text arguments in the received exec array
 #define MOD_MAX_EXEC_ARG_LEN 100
 
 /**

--- a/device_modules/fdo_sys/fdo_sys.h
+++ b/device_modules/fdo_sys/fdo_sys.h
@@ -19,7 +19,8 @@
 #define MOD_ACTIVE_TAG "active"
 #define MOD_ACTIVE_STATUS "1"
 
-#define MOD_MAX_DATA_LEN 1024
+#define MOD_MAX_EXEC_LEN 1024
+#define MOD_MAX_EXEC_ARG_LEN 100
 
 /**
  * The registered callback method for 'fdo_sys' Owner ServiceInfo module.

--- a/device_modules/fdo_sys/sys_utils_linux.c
+++ b/device_modules/fdo_sys/sys_utils_linux.c
@@ -97,14 +97,11 @@ bool process_data(fdoSysModMsg type, uint8_t *data, uint32_t data_len,
 	FILE *fp = NULL;
 	int error_code = 0;
 	char *command = NULL;
-	static char exec_instructions[MOD_MAX_DATA_LEN];
-	static size_t exec_instructions_sz = 0;
+	size_t command_len = data_len;
 	const char exec_terminator = '\0';
 	const char *space_delimeter_str = " ";
 	char *exec_token, *exec_token_next;
 	int exec_token_index = 0;
-	size_t data_index = 0;
-	bool exec_received_complete = false;
 
 	if (!data || !data_len) {
 #ifdef DEBUG_LOGS
@@ -141,114 +138,76 @@ bool process_data(fdoSysModMsg type, uint8_t *data, uint32_t data_len,
 	}
 
 	// For Exec call
-	// TO-DO : Update based on fdo_sys spec when PRI implements it.
 	if (type == FDO_SYS_MOD_MSG_EXEC) {
 
-		// check if the received instruction is ending now with \0\0
-		if (exec_terminator == data[data_len - 1] &&
-			exec_terminator == data[data_len - 2]) {
-			exec_received_complete = true;
+		if (exec_terminator != data[data_len]) {
+#ifdef DEBUG_LOGS
+			printf("fdo_sys exec : Command is not null-terminated\n");
+#endif
+			goto end;
 		}
-		// append the exec instructions (whether partial or full)
-		// replace '\0' with ' '. this leaves two ' ' at the end
-		while (data_index < data_len) {
-			// -1 for final '\0'
-			if (exec_instructions_sz >= MOD_MAX_DATA_LEN - 1) {
+		// copy the 'exec_instructions' array upto 'exec_instructions_sz'
+		// into 'command'. check if it is '\0' delimeted, and get the file name
+		command = (char *) ModuleAlloc(data_len);
+		if (command == NULL) {
 #ifdef DEBUG_LOGS
-				printf("fdo_sys exec: Received command is too large. Cannot process\n");
+			printf("fdo_sys exec : Failed to alloc for command\n");
 #endif
-				goto end;
-			}
-			if (exec_terminator == data[data_index]) {
-				exec_instructions[exec_instructions_sz++] = space_delimeter_str[0];
-				data_index++;
-			} else {
-				exec_instructions[exec_instructions_sz++] = data[data_index++];
-			}
+			goto end;
 		}
-		// set the 2nd last character to '\0'
-		exec_instructions[exec_instructions_sz - 2] = exec_terminator;
 
-		// if exec command is received completely, execute the instruction
-		// if not, continue and look for it in the next iteration
-		if (exec_received_complete) {
+		if (0 != strncpy_s(command, command_len,
+			(char *) data, command_len)) {
+			goto end;
+		}
 
-			// copy the 'exec_instructions' array upto 'exec_instructions_sz'
-			// into 'command'. check if it is '\0' delimeted, and get the file name
-			command = (char *) ModuleAlloc(exec_instructions_sz);
-			if (command == NULL) {
+		// exec_token empties itself in the tokenization process and
+		// exec_token_next is provided for internal usage for strtok_s
+		exec_token = strtok_s(command, &command_len,
+			space_delimeter_str, &exec_token_next);
+		while (exec_token) {
+			// 1st ' ' i.e 2nd token, gives the filename that will be executed.
+			if (exec_token_index == 1) {
+				// Proper error check for system call
+				// Allow only filename (no absolute path for secure env)
+				if (is_valid_filename((const char *) exec_token) == false) {
 #ifdef DEBUG_LOGS
-				printf("fdo_sys exec : Failed to alloc for command\n");
+					printf("fdo_sys exec : Failed to get file name from command\n");
 #endif
-				goto end;
-			}
-
-			if (0 != strncpy_s(command, exec_instructions_sz,
-				&exec_instructions[0], exec_instructions_sz)) {
-				goto end;
-			}
-
-			// exec_token empties itself in the tokenization process and
-			// exec_token_next is provided for internal usage for strtok_s
-			exec_token = strtok_s(exec_instructions, &exec_instructions_sz,
-				space_delimeter_str, &exec_token_next);
-			while (exec_token) {
-				// 1st '\0' i.e 2nd token, gives the filename that will be executed.
-				if (exec_token_index == 1) {
-					// Proper error check for system call
-					// Allow only filename (no absolute path for secure env)
-					if (is_valid_filename((const char *) exec_token) == false) {
-#ifdef DEBUG_LOGS
-						printf("fdo_sys exec : Failed to get file name from command\n");
-#endif
-						goto end;
-					}
-					
-					// Executable permission for current user for the file
-					if (chmod(exec_token, 0700)) {
-#ifdef DEBUG_LOGS
-						printf("fdo_sys exec : Failed to set execute permission in %s\n",
-							file_name);
-#endif
-						goto end;
-					}
+					goto end;
 				}
-				exec_token = strtok_s(NULL, &exec_instructions_sz,
-					space_delimeter_str, &exec_token_next);
-				exec_token_index++;
+					
+				// Executable permission for current user for the file
+				if (chmod(exec_token, 0700)) {
+#ifdef DEBUG_LOGS
+					printf("fdo_sys exec : Failed to set execute permission in %s\n",
+						file_name);
+#endif
+					goto end;
+				}
 			}
-
-#ifdef DEBUG_LOGS
-			printf("fdo_sys exec: Received command completely. Executing...\n");
-#endif
-			error_code = system(command);
-			if (error_code == -1) {
-#ifdef DEBUG_LOGS
-				printf("fdo_sys exec : Failed to execute command for file %s\n", file_name);
-#endif
-				goto end;
-			}
-
-		} else {
-#ifdef DEBUG_LOGS
-				printf("fdo_sys exec : Received command partially\n");
-#endif
-			// received partially. return now so that we don't clear exec_instructions
-			return true;
+			exec_token = strtok_s(NULL, &command_len,
+				space_delimeter_str, &exec_token_next);
+			exec_token_index++;
 		}
+
+#ifdef DEBUG_LOGS
+		printf("fdo_sys exec: Received command completely. Executing...\n");
+#endif
+		error_code = system((char *) data);
+		if (error_code == -1) {
+#ifdef DEBUG_LOGS
+			printf("fdo_sys exec : Failed to execute command for file %s\n", file_name);
+#endif
+			goto end;
+		}
+
 		ret = true;
 	}
 
 end:
 	if (command)
 		ModuleFree(command);
-	// clear for next exec
-	if (0 != memset_s(&exec_instructions, sizeof(exec_instructions), 0)) {
-#ifdef DEBUG_LOGS
-		printf("fdo_sys exec : Failed to clear exec instructions\n");
-#endif
-	}
-	exec_instructions_sz = 0;
 
 	if (fp) {
 		if (fclose(fp) == EOF) {

--- a/lib/fdo.c
+++ b/lib/fdo.c
@@ -333,11 +333,11 @@ static fdo_sdk_status app_initialize(void)
 	}
 #endif
 
-	// read the file at path MAX_SERVICEINFO_SIZE to get the maximum ServiceInfo size
+	// read the file at path MAX_SERVICEINFO_SZ_FILE to get the maximum ServiceInfo size
 	// that will be supported for both Owner and Device ServiceInfo
 	// default to MIN_SERVICEINFO_SZ if the file is empty/non-existent
 	// file of size 1 is also considered an empty file containing new-line character
-	fsize = fdo_blob_size((char *)MAX_SERVICEINFO_SIZE, FDO_SDK_RAW_DATA);
+	fsize = fdo_blob_size((char *)MAX_SERVICEINFO_SZ_FILE, FDO_SDK_RAW_DATA);
 	if (fsize == 0 || fsize == 1) {
 		g_fdo_data->prot.maxDeviceServiceInfoSz = MIN_SERVICEINFO_SZ;
 		g_fdo_data->prot.maxOwnerServiceInfoSz = MIN_SERVICEINFO_SZ;
@@ -346,7 +346,7 @@ static fdo_sdk_status app_initialize(void)
 		if (buffer == NULL) {
 			LOG(LOG_ERROR, "malloc failed\n");
 		} else {
-			if (fdo_blob_read((char *)MAX_SERVICEINFO_SIZE, FDO_SDK_RAW_DATA,
+			if (fdo_blob_read((char *)MAX_SERVICEINFO_SZ_FILE, FDO_SDK_RAW_DATA,
 					(uint8_t *)buffer, fsize) == -1) {
 				LOG(LOG_ERROR, "Failed to read Manufacture DN\n");
 			}
@@ -357,7 +357,7 @@ static fdo_sdk_status app_initialize(void)
 			else if (max_serviceinfo_sz >= MAX_SERVICEINFO_SZ) {
 				max_serviceinfo_sz = MAX_SERVICEINFO_SZ;
 			}
-			prot_buff_sz = max_serviceinfo_sz + BUFF_MARGIN;
+			prot_buff_sz = max_serviceinfo_sz + MSG_METADATA_SIZE;
 			g_fdo_data->prot.maxDeviceServiceInfoSz = max_serviceinfo_sz;
 			g_fdo_data->prot.maxOwnerServiceInfoSz = max_serviceinfo_sz;
 		}

--- a/lib/fdo.c
+++ b/lib/fdo.c
@@ -300,6 +300,9 @@ fdo_dev_cred_t *app_get_credentials(void)
 static fdo_sdk_status app_initialize(void)
 {
 	int ret = FDO_ERROR;
+	int32_t fsize;
+	int max_serviceinfo_sz, prot_buff_sz = CBOR_BUFFER_LENGTH;
+	char *buffer = NULL;
 
 	if (!g_fdo_data)
 		return FDO_ERROR;
@@ -330,17 +333,50 @@ static fdo_sdk_status app_initialize(void)
 	}
 #endif
 
+	// read the file at path MAX_SERVICEINFO_SIZE to get the maximum ServiceInfo size
+	// that will be supported for both Owner and Device ServiceInfo
+	// default to MIN_SERVICEINFO_SZ if the file is empty/non-existent
+	// file of size 1 is also considered an empty file containing new-line character
+	fsize = fdo_blob_size((char *)MAX_SERVICEINFO_SIZE, FDO_SDK_RAW_DATA);
+	if (fsize == 0 || fsize == 1) {
+		g_fdo_data->prot.maxDeviceServiceInfoSz = MIN_SERVICEINFO_SZ;
+		g_fdo_data->prot.maxOwnerServiceInfoSz = MIN_SERVICEINFO_SZ;
+	} else if (fsize > 0) {
+		buffer = fdo_alloc(fsize + 1);
+		if (buffer == NULL) {
+			LOG(LOG_ERROR, "malloc failed\n");
+		} else {
+			if (fdo_blob_read((char *)MAX_SERVICEINFO_SIZE, FDO_SDK_RAW_DATA,
+					(uint8_t *)buffer, fsize) == -1) {
+				LOG(LOG_ERROR, "Failed to read Manufacture DN\n");
+			}
+			max_serviceinfo_sz = atoi(buffer);
+			if (max_serviceinfo_sz <= MIN_SERVICEINFO_SZ) {
+				max_serviceinfo_sz = MIN_SERVICEINFO_SZ;
+			}
+			else if (max_serviceinfo_sz >= MAX_SERVICEINFO_SZ) {
+				max_serviceinfo_sz = MAX_SERVICEINFO_SZ;
+			}
+			prot_buff_sz = max_serviceinfo_sz + BUFF_MARGIN;
+			g_fdo_data->prot.maxDeviceServiceInfoSz = max_serviceinfo_sz;
+			g_fdo_data->prot.maxOwnerServiceInfoSz = max_serviceinfo_sz;
+		}
+	}
+	if (buffer != NULL) {
+		fdo_free(buffer);
+	}
+
 	/* 
 	* Initialize and allocate memory for the FDOW/FDOR blocks before starting the spec's 
 	* protocol execution. Reuse the allocated memory by emptying the contents.
 	*/ 
 	if (!fdow_init(&g_fdo_data->prot.fdow) ||
-		!fdo_block_alloc(&g_fdo_data->prot.fdow.b)) {
+		!fdo_block_alloc_with_size(&g_fdo_data->prot.fdow.b, prot_buff_sz)) {
 		LOG(LOG_ERROR, "fdow_init() failed!\n");
 		return FDO_ERROR;
 	}
 	if (!fdor_init(&g_fdo_data->prot.fdor) ||
-		!fdo_block_alloc(&g_fdo_data->prot.fdor.b)) {
+		!fdo_block_alloc_with_size(&g_fdo_data->prot.fdor.b, prot_buff_sz)) {
 		LOG(LOG_ERROR, "fdor_init() failed!\n");
 		return FDO_ERROR;
 	}
@@ -412,8 +448,6 @@ static fdo_sdk_status app_initialize(void)
 	// support is added.
 	fdo_service_info_add_kv_int(g_fdo_data->service_info, "devmod:nummodules",
 			    	1);
-	fdo_service_info_add_kv_str(g_fdo_data->service_info,
-				    "devmod:modules", "sdo_sys");
 
 	if (fdo_null_ipaddress(&g_fdo_data->prot.i1) == false) {
 		return FDO_ERROR;

--- a/lib/include/fdoprot.h
+++ b/lib/include/fdoprot.h
@@ -157,9 +157,13 @@
  */
 #define DEBUGBUFSZ 1024
 
-// TO-DO : Update with flags during serviceinfo implementation
-#define MAXOWNERSERVICEINFOSZ 1300
-#define MAXDEVICESERVICEINFOSZ 1300
+// minimum ServiceInfo size
+#define MIN_SERVICEINFO_SZ 1300
+// maximum ServiceInfo size
+#define MAX_SERVICEINFO_SZ 8192
+// margin that gets added to either max or min ServiceInfo size to create
+// the final buffer to read/write protcol (DI/TO1/TO2)
+#define BUFF_MARGIN 700
 
 #if defined(REUSE_SUPPORTED)
 static const bool reuse_supported = true;
@@ -206,6 +210,7 @@ typedef struct fdo_prot_s {
 	uint16_t serv_req_info_num;
 	int maxOwnerServiceInfoSz;
 	int maxDeviceServiceInfoSz;
+	bool device_serviceinfo_ismore;
 	int owner_supplied_service_info_num;
 	int owner_supplied_service_info_rcv;
 	fdo_owner_supplied_credentials_t *osc;

--- a/lib/include/fdoprot.h
+++ b/lib/include/fdoprot.h
@@ -163,7 +163,7 @@
 #define MAX_SERVICEINFO_SZ 8192
 // margin that gets added to either max or min ServiceInfo size to create
 // the final buffer to read/write protcol (DI/TO1/TO2)
-#define BUFF_MARGIN 700
+#define MSG_METADATA_SIZE 700
 
 #if defined(REUSE_SUPPORTED)
 static const bool reuse_supported = true;

--- a/lib/include/fdotypes.h
+++ b/lib/include/fdotypes.h
@@ -549,6 +549,7 @@ bool fdo_signature_verification(fdo_byte_array_t *plain_text,
 
 bool fdo_compare_public_keys(fdo_public_key_t *pk1, fdo_public_key_t *pk2);
 bool fdo_serviceinfo_write(fdow_t *fdow, fdo_service_info_t *si);
+bool fdo_serviceinfo_modules_list_write(fdow_t *fdow);
 
 /*==================================================================*/
 /* Service Info functionality */

--- a/lib/prot/to2/msg66.c
+++ b/lib/prot/to2/msg66.c
@@ -94,10 +94,12 @@ int32_t msg66(fdo_prot_t *ps)
 		}
 	}
 
-	if (!fdow_signed_int(&ps->fdow, MAXOWNERSERVICEINFOSZ)) {
+	if (!fdow_signed_int(&ps->fdow, ps->maxOwnerServiceInfoSz)) {
 		LOG(LOG_ERROR, "TO2.DeviceServiceInfoReady: Failed to write maxOwnerServiceInfoSz\n");
 		goto err;
 	}
+	LOG(LOG_DEBUG, "TO2.DeviceServiceInfoReady: Sent maxOwnerServiceInfoSz = %d\n",
+		ps->maxOwnerServiceInfoSz);
 
 	if (!fdow_end_array(&ps->fdow)) {
 		LOG(LOG_ERROR, "TO2.DeviceServiceInfoReady: Failed to end array\n");

--- a/lib/prot/to2/msg67.c
+++ b/lib/prot/to2/msg67.c
@@ -83,13 +83,17 @@ int32_t msg67(fdo_prot_t *ps)
 			"TO2.OwnerServiceInfoReady: Received maxDeviceServiceInfoSz is less than "
 			"the minimum size supported. Defaulting to %d\n",
 			ps->maxDeviceServiceInfoSz);
-	}
-	else if	(rec_maxDeviceServiceInfoSz >= ps->maxDeviceServiceInfoSz) {
+	} else if (rec_maxDeviceServiceInfoSz >= ps->maxDeviceServiceInfoSz) {
 		// nothing to do, just log it
 		LOG(LOG_DEBUG,
 			"TO2.OwnerServiceInfoReady: Received maxDeviceServiceInfoSz is more than "
 			"the maximum size supported. Defaulting to %d\n",
 			ps->maxDeviceServiceInfoSz);
+	} else {
+		// set the received value
+		ps->maxDeviceServiceInfoSz = rec_maxDeviceServiceInfoSz;
+		LOG(LOG_DEBUG,
+			"TO2.OwnerServiceInfoReady: Received maxDeviceServiceInfoSz is valid\n");
 	}
 
 	if (!fdor_end_array(&ps->fdor)) {

--- a/lib/prot/to2/msg67.c
+++ b/lib/prot/to2/msg67.c
@@ -53,7 +53,7 @@ int32_t msg67(fdo_prot_t *ps)
 		goto err;
 	}
 
-	// maxDeviceServiceInfoSz = CBOR NULL implies that MAXDEVICESERVICEINFOSZ should be accepted
+	// maxDeviceServiceInfoSz = CBOR NULL implies that MIN_SERVICEINFO_SZ should be accepted
 	// maxDeviceServiceInfoSz = Unsigned Integer implies that the given value should be processed
 	if (fdor_is_value_signed_int(&ps->fdor)) {
 		if (!fdor_signed_int(&ps->fdor, &rec_maxDeviceServiceInfoSz)) {
@@ -74,11 +74,22 @@ int32_t msg67(fdo_prot_t *ps)
 		goto err;
 	}
 
-	if (rec_maxDeviceServiceInfoSz > 0 &&
-		rec_maxDeviceServiceInfoSz < MAXDEVICESERVICEINFOSZ) {
-		ps->maxDeviceServiceInfoSz = rec_maxDeviceServiceInfoSz;
-	} else {
-		ps->maxDeviceServiceInfoSz = MAXDEVICESERVICEINFOSZ;
+	LOG(LOG_DEBUG, "TO2.OwnerServiceInfoReady: Received maxDeviceServiceInfoSz = %d\n",
+		rec_maxDeviceServiceInfoSz);
+	if (rec_maxDeviceServiceInfoSz <= MIN_SERVICEINFO_SZ) {
+		// default to minimum and log it
+		ps->maxDeviceServiceInfoSz = MIN_SERVICEINFO_SZ;
+		LOG(LOG_DEBUG,
+			"TO2.OwnerServiceInfoReady: Received maxDeviceServiceInfoSz is less than "
+			"the minimum size supported. Defaulting to %d\n",
+			ps->maxDeviceServiceInfoSz);
+	}
+	else if	(rec_maxDeviceServiceInfoSz >= ps->maxDeviceServiceInfoSz) {
+		// nothing to do, just log it
+		LOG(LOG_DEBUG,
+			"TO2.OwnerServiceInfoReady: Received maxDeviceServiceInfoSz is more than "
+			"the maximum size supported. Defaulting to %d\n",
+			ps->maxDeviceServiceInfoSz);
 	}
 
 	if (!fdor_end_array(&ps->fdor)) {

--- a/lib/prot/to2/msg68.c
+++ b/lib/prot/to2/msg68.c
@@ -55,16 +55,21 @@ int32_t msg68(fdo_prot_t *ps)
 	// 1 for 'devmod' Device ServiceInfo
 	// however, it should contain total number of Device ServiceInfo rounds
 	ps->total_dsi_rounds = 1;
+	// since there is only 1 round-trip, isMoreServiceInfo is always false
+	ps->device_serviceinfo_ismore = false;
 
 	if (ps->service_info && ps->serv_req_info_num == 0) {
 
-		if (!fdow_boolean(&ps->fdow, true)) {
+		// for a single module and MIN_SERVICEINFO_SZ, only a single round-trip suffices
+		// TO-DO : To be updated when support for multiple Device ServiceInfo is added
+		if (!fdow_boolean(&ps->fdow, ps->device_serviceinfo_ismore)) {
 			LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to write IsMoreServiceInfo\n");
 			return false;
 		}
 
+		fdo_service_info_t *serviceinfo_itr = ps->service_info;
 		// Construct and write platform DSI's into a single msg
-		if (!fdo_serviceinfo_write(&ps->fdow, ps->service_info)) {
+		if (!fdo_serviceinfo_write(&ps->fdow, serviceinfo_itr)) {
 			LOG(LOG_ERROR, "Error in combining platform DSI's!\n");
 			goto err;
 		}
@@ -75,7 +80,7 @@ int32_t msg68(fdo_prot_t *ps)
 	} else {
 
 		// Empty ServiceInfo. send [false, []]
-		if (!fdow_boolean(&ps->fdow, false)) {
+		if (!fdow_boolean(&ps->fdow, ps->device_serviceinfo_ismore)) {
 			LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to write IsMoreServiceInfo\n");
 			return false;
 		}


### PR DESCRIPTION
- Replaced the existing sdo_sys Owner ServiceInfo module implementation
to fdo_sys.
- Updated devmod:modules to align with FDO spec and moved it to
fdo_types.c
- Added support for configurable MTU by allowing the user to decide the
maximum ServiceInfo size that the device can support, by updating a file
data/max_serviceinfo_sz. This inturn, decides the size of the buffer
being allocated for protocol-specific messages.
- Added a flag to track  TO2.DeviceServiceInfo.IsMoreServiceInfo that is
used to check in TO2.OwnerServiceInfo for empty ServiceInfo scenario.
- Fixed an issue where the ServiceInfo module iteration was done on the
primary pointer leading to 'module not found' error at certain
situations.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>