### PR TITLE
Adding RendezvousInfo comparison and updating non-resale scenario

### DIFF
--- a/lib/include/fdotypes.h
+++ b/lib/include/fdotypes.h
@@ -591,6 +591,8 @@ bool fdo_compare_hashes(fdo_hash_t *hash1, fdo_hash_t *hash2);
 bool fdo_compare_byte_arrays(fdo_byte_array_t *ba1, fdo_byte_array_t *ba2);
 bool fdo_compare_rv_lists(fdo_rendezvous_list_t *rv_list1,
 			  fdo_rendezvous_list_t *rv_list2);
+bool fdo_rendezvous_instr_compare(fdo_rendezvous_t *entry1,
+	fdo_rendezvous_t *entry2);
 
 void fdo_log_block(fdo_block_t *fdob);
 

--- a/lib/prot/to2/msg66.c
+++ b/lib/prot/to2/msg66.c
@@ -89,7 +89,11 @@ int32_t msg66(fdo_prot_t *ps)
 		} else {
 			LOG(LOG_DEBUG,
 			    "TO2.DeviceServiceInfoReady: *****Resale triggered but not supported.*****\n");
-			// TO-DO: This case is no more, update the flags
+			// write CBOR NULL
+			if (!fdow_null(&ps->fdow)) {
+				LOG(LOG_ERROR, "TO2.DeviceServiceInfoReady: Failed to write ReplacementHMac\n");
+				goto err;
+			}
 			goto err;
 		}
 	}


### PR DESCRIPTION
- Previously RendezvousInfo comparioson was limited to them being
non-null. Updated the code to compare RendezvousDirective and
RendezvousInstr within.
- In non-resale scenario, now returning CBOR NULL as replacementHmax,
instead of throwing error.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>