### PR TITLE
Fixing few issues

### DIFF
--- a/lib/fdocred.c
+++ b/lib/fdocred.c
@@ -540,10 +540,12 @@ bool fdo_ove_hash_prev_entry_save(fdow_t *fdow, fdo_ownership_voucher_t *ov,
 	fdo_byte_array_t *enc_ovheader = NULL;
 	fdo_byte_array_t *enc_hmac = NULL;
 	uint8_t *hash_prev_entry = NULL;
+	// save the default buffer size, set it back at the end
+	size_t fdow_buff_default_sz = fdow->b.block_size;
 
 	// reset the block to write OVHeader
 	fdo_block_reset(&fdow->b);
-	fdow->b.block_size = CBOR_BUFFER_LENGTH;
+	fdow->b.block_size = fdow_buff_default_sz;
 	if (!fdow_encoder_init(fdow)) {
 		LOG(LOG_ERROR, "OVEHashPrevEntry: Failed to initialize FDOW encoder\n");
 		goto exit;
@@ -563,7 +565,7 @@ bool fdo_ove_hash_prev_entry_save(fdow_t *fdow, fdo_ownership_voucher_t *ov,
 
 	// reset the FDOW block to write HMac
 	fdo_block_reset(&fdow->b);
-	fdow->b.block_size = CBOR_BUFFER_LENGTH;
+	fdow->b.block_size = fdow_buff_default_sz;
 	if (!fdow_encoder_init(fdow)) {
 		LOG(LOG_ERROR, "OVEHashPrevEntry: Failed to initialize FDOW encoder\n");
 		goto exit;
@@ -617,7 +619,7 @@ bool fdo_ove_hash_prev_entry_save(fdow_t *fdow, fdo_ownership_voucher_t *ov,
 
 	// reset the given FDOW for the next encoding
 	fdo_block_reset(&fdow->b);
-	fdow->b.block_size = CBOR_BUFFER_LENGTH;
+	fdow->b.block_size = fdow_buff_default_sz;
 	if (!fdow_encoder_init(fdow)) {
 		LOG(LOG_ERROR, "OVEHashPrevEntry: Failed to initialize FDOW encoder\n");
 		goto exit;

--- a/lib/fdotypes.c
+++ b/lib/fdotypes.c
@@ -2729,6 +2729,8 @@ bool fdo_encrypted_packet_windup(fdow_t *fdow, int type, fdo_iv_t *iv)
 
 	fdo_block_t *fdob = &fdow->b;
 	bool ret = false;
+	// save the default buffer size, set it back at the end
+	size_t fdow_buff_default_sz = fdob->block_size;
 
 	// find the encoded cleartext length
 	size_t payload_length = 0;
@@ -2763,7 +2765,7 @@ bool fdo_encrypted_packet_windup(fdow_t *fdow, int type, fdo_iv_t *iv)
 	// reset the FDOW block to write COSE_Encrypt0 (ETMInnerBlock)
 	// This clears the unencrypted (clear text) as well
 	fdo_block_reset(&fdow->b);
-	fdow->b.block_size = CBOR_BUFFER_LENGTH;
+	fdow->b.block_size = fdow_buff_default_sz;
 	if (!fdow_encoder_init(fdow)) {
 		LOG(LOG_ERROR,
 			"Encrypted Message (encrypt): Failed to initialize FDOW encoder\n");
@@ -2793,7 +2795,7 @@ bool fdo_encrypted_packet_windup(fdow_t *fdow, int type, fdo_iv_t *iv)
 
 	// reset the FDOW block to prepare for writing COSE_Sign1 (ETMOuterBlock)
 	fdo_block_reset(&fdow->b);
-	fdow->b.block_size = CBOR_BUFFER_LENGTH;
+	fdow->b.block_size = fdow_buff_default_sz;
 	if (!fdow_encoder_init(fdow)) {
 		LOG(LOG_ERROR,
 			"Encrypted Message (encrypt): Failed to initialize FDOW encoder\n");

--- a/lib/include/fdoprot.h
+++ b/lib/include/fdoprot.h
@@ -211,6 +211,7 @@ typedef struct fdo_prot_s {
 	int maxOwnerServiceInfoSz;
 	int maxDeviceServiceInfoSz;
 	bool device_serviceinfo_ismore;
+	size_t prot_buff_sz;
 	int owner_supplied_service_info_num;
 	int owner_supplied_service_info_rcv;
 	fdo_owner_supplied_credentials_t *osc;

--- a/lib/prot/to1/msg32.c
+++ b/lib/prot/to1/msg32.c
@@ -86,7 +86,7 @@ int32_t msg32(fdo_prot_t *ps)
 
 	// reset the FDOW block to prepare for the next encoding.
 	fdo_block_reset(&ps->fdow.b);
-	ps->fdow.b.block_size = CBOR_BUFFER_LENGTH;
+	ps->fdow.b.block_size = ps->prot_buff_sz;
 	if (!fdow_encoder_init(&ps->fdow)) {
 		LOG(LOG_ERROR, "TO1.ProveToRV: Failed to initilize FDOW encoder\n");
 		goto err;

--- a/lib/prot/to2/msg61.c
+++ b/lib/prot/to2/msg61.c
@@ -263,7 +263,7 @@ int32_t msg61(fdo_prot_t *ps)
 	}
 	// reset the FDOW block to prepare for OVEHashPrevEntry
 	fdo_block_reset(&ps->fdow.b);
-	ps->fdow.b.block_size = CBOR_BUFFER_LENGTH;
+	ps->fdow.b.block_size = ps->prot_buff_sz;
 	if (!fdow_encoder_init(&ps->fdow)) {
 		LOG(LOG_ERROR, "TO2.ProveOVHdr: Failed to initilize FDOW encoder\n");
 		goto err;

--- a/lib/prot/to2/msg64.c
+++ b/lib/prot/to2/msg64.c
@@ -83,7 +83,7 @@ int32_t msg64(fdo_prot_t *ps)
 	// reset the given FDOW for the next encoding
 	// This is done out of cycle here because FDOW object was used in Type 63
 	fdo_block_reset(&ps->fdow.b);
-	ps->fdow.b.block_size = CBOR_BUFFER_LENGTH;
+	ps->fdow.b.block_size = ps->prot_buff_sz;
 	if (!fdow_encoder_init(&ps->fdow)) {
 		LOG(LOG_ERROR, "OVEHashPrevEntry: Failed to initialize FDOW encoder\n");
 		goto err;
@@ -115,7 +115,7 @@ int32_t msg64(fdo_prot_t *ps)
 
 	// reset the FDOW block to prepare for the next encoding.
 	fdo_block_reset(&ps->fdow.b);
-	ps->fdow.b.block_size = CBOR_BUFFER_LENGTH;
+	ps->fdow.b.block_size = ps->prot_buff_sz;
 	if (!fdow_encoder_init(&ps->fdow)) {
 		LOG(LOG_ERROR, "TO2.ProveDevice: Failed to initilize FDOW encoder\n");
 		goto err;


### PR DESCRIPTION
Fixing the following issues:
- Fixing a sceario where 0 was returned instead of -1 on onboarding
failure.
- Fixing a scenario where buffer overflow was happening in case the
response message was more than the buffer size allocated. To accomodate
this, a new state variable has been created that stores the allocated
buffer size and is used throughout the application now.
- Fixing mememory leak in retry scenario for variable 'resolved_dns'.
- Updating Log level for 'Skipping TO1' message in case RVBYPASS is
encountered.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>