### PR TITLE
Update Public key constants as per FDO spec

### DIFF
--- a/crypto/include/fdoCryptoHal.h
+++ b/crypto/include/fdoCryptoHal.h
@@ -96,7 +96,7 @@ int32_t crypto_hal_hmac(uint8_t hmac_type, const uint8_t *buffer,
  * @param key_param2Length[in] - size of public key2, type size_t
  * @return 0 if true, else -1.
  */
-int32_t crypto_hal_sig_verify(uint8_t key_encoding, uint8_t key_algorithm,
+int32_t crypto_hal_sig_verify(uint8_t key_encoding, int key_algorithm,
 			      const uint8_t *message, uint32_t message_length,
 			      const uint8_t *message_signature,
 			      uint32_t signature_length,

--- a/crypto/mbedtls/mbedtls_ECDSAVerifyRoutines.c
+++ b/crypto/mbedtls/mbedtls_ECDSAVerifyRoutines.c
@@ -37,7 +37,7 @@
  * @return 0 if true, else -1.
 
  */
-int32_t crypto_hal_sig_verify(uint8_t key_encoding, uint8_t key_algorithm,
+int32_t crypto_hal_sig_verify(uint8_t key_encoding, int key_algorithm,
 			      const uint8_t *message, uint32_t message_length,
 			      const uint8_t *message_signature,
 			      uint32_t signature_length,

--- a/crypto/mbedtls/mbedtls_RSAVerifyRoutines.c
+++ b/crypto/mbedtls/mbedtls_RSAVerifyRoutines.c
@@ -42,7 +42,7 @@
  * @return 0 if true, else -1.
 
  */
-int32_t crypto_hal_sig_verify(uint8_t key_encoding, uint8_t key_algorithm,
+int32_t crypto_hal_sig_verify(uint8_t key_encoding, int key_algorithm,
 			      const uint8_t *message, uint32_t message_length,
 			      const uint8_t *message_signature,
 			      uint32_t signature_length,

--- a/crypto/openssl/openssl_ECDSAVerifyRoutines.c
+++ b/crypto/openssl/openssl_ECDSAVerifyRoutines.c
@@ -34,7 +34,7 @@
  * @return 0 if true, else -1.
 
  */
-int32_t crypto_hal_sig_verify(uint8_t key_encoding, uint8_t key_algorithm,
+int32_t crypto_hal_sig_verify(uint8_t key_encoding, int key_algorithm,
 			      const uint8_t *message, uint32_t message_length,
 			      const uint8_t *message_signature,
 			      uint32_t signature_length,

--- a/crypto/openssl/openssl_RSAVerifyRoutines.c
+++ b/crypto/openssl/openssl_RSAVerifyRoutines.c
@@ -182,7 +182,7 @@ err:
  * @param key_param2Length - size of public key2, type size_t
  * @return 0 if true, else -1.
  */
-int32_t crypto_hal_sig_verify(uint8_t key_encoding, uint8_t key_algorithm,
+int32_t crypto_hal_sig_verify(uint8_t key_encoding, int key_algorithm,
 			      const uint8_t *message, uint32_t message_length,
 			      const uint8_t *message_signature,
 			      uint32_t signature_length,

--- a/crypto/se/se_ECDSAVerifyRoutines.c
+++ b/crypto/se/se_ECDSAVerifyRoutines.c
@@ -33,7 +33,7 @@
  * @return 0 if true, else -1.
 
  */
-int32_t crypto_hal_sig_verify(uint8_t key_encoding, uint8_t key_algorithm,
+int32_t crypto_hal_sig_verify(uint8_t key_encoding, int key_algorithm,
 			      const uint8_t *message, uint32_t message_length,
 			      const uint8_t *message_signature,
 			      uint32_t signature_length,

--- a/lib/include/fdotypes.h
+++ b/lib/include/fdotypes.h
@@ -186,8 +186,8 @@ typedef struct {
 #define FDO_PK_HASH_HMAC_SHA_384 114
 
 // 3.3.4, PublicKey types (pkType)
-#define FDO_CRYPTO_PUB_KEY_ALGO_ECDSAp256 13
-#define FDO_CRYPTO_PUB_KEY_ALGO_ECDSAp384 14
+#define FDO_CRYPTO_PUB_KEY_ALGO_ECDSAp256 -7
+#define FDO_CRYPTO_PUB_KEY_ALGO_ECDSAp384 -35
 
 // TO-DO: Legacy, Used in RSA-based crypto operations.
 // Remove when the classes themselves are removed.


### PR DESCRIPTION
- Update the used PublicKey.pkType constant for EC256 and EC284 key
types as FDO spec.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>