### PR TITLE
Fix processing of Ownership Voucher of size 2 or more

### DIFF
--- a/lib/prot/to2/msg63.c
+++ b/lib/prot/to2/msg63.c
@@ -273,6 +273,13 @@ int32_t msg63(fdo_prot_t *ps)
 	ps->ov_entry_num++;
 	if (ps->ov_entry_num < ps->ovoucher->num_ov_entries) {
 		ps->state = FDO_STATE_TO2_SND_GET_OP_NEXT_ENTRY;
+		// reset FDOW because it was used in this method, out of place
+		fdo_block_reset(&ps->fdow.b);
+		ps->fdor.b.block_size = ps->prot_buff_sz;
+		if (!fdow_encoder_init(&ps->fdow)) {
+			LOG(LOG_ERROR, "TO2.OVNextEntry: Failed to initialize FDOW encoder\n");
+			goto err;
+		}
 	} else {
 		LOG(LOG_DEBUG,
 		    "TO2.OVNextEntry: All %d OVEntry(s) have been "


### PR DESCRIPTION
- Fix an issue where an OwnershipVoucher of size 2 or more was not going
through the Type 62-63 loop correctly, by clearing out the FDOW buffer.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>