### PR TITLE
Replace TLS/HTTPS constants for RVTO2Addr

### DIFF
--- a/lib/fdo.c
+++ b/lib/fdo.c
@@ -1241,8 +1241,8 @@ static bool _STATE_TO2(void)
 			}
 			dns = g_fdo_data->current_rvto2addrentry->rvdns;
 			port = g_fdo_data->current_rvto2addrentry->rvport;
-			if (g_fdo_data->current_rvto2addrentry->rvprotocol == RVPROTHTTPS ||
-				g_fdo_data->current_rvto2addrentry->rvprotocol == RVPROTTLS) {
+			if (g_fdo_data->current_rvto2addrentry->rvprotocol == PROTHTTPS ||
+				g_fdo_data->current_rvto2addrentry->rvprotocol == PROTTLS) {
 				tls = true;
 			}
 			// prepare for next iteration beforehand

--- a/lib/include/fdotypes.h
+++ b/lib/include/fdotypes.h
@@ -408,6 +408,16 @@ bool fdo_cose_write_protected_header(fdow_t *fdow, fdo_cose_protected_header_t *
 bool fdo_cose_write_unprotected_header(fdow_t *fdow);
 bool fdo_cose_write(fdow_t *fdow, fdo_cose_t *cose);
 
+/*
+ * This is a lookup on all possible TransportProtocol values (Section 3.3.12)
+ */
+#define PROTTCP 1
+#define PROTTLS 2
+#define PROTHTTP 3
+#define PROTCOAP 4
+#define PROTHTTPS 5
+#define PROTCOAPS 6
+
 typedef struct fdo_rvto2addr_entry_s {
 	fdo_byte_array_t *rvip;
 	fdo_string_t *rvdns;


### PR DESCRIPTION
- Add constants as per Section 3.3.12 (Transport protocol) of FDO spec,
and replace the usage of RVProtocol value with these new constants while
invoking TO2.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>