### PR TITLE
Replace atoi() with strtol() and update few debug logs

### DIFF
--- a/crypto/common/fdoKeyExchange.c
+++ b/crypto/common/fdoKeyExchange.c
@@ -39,7 +39,6 @@ int32_t fdo_kex_init(void)
 		goto err;
 	}
 
-	LOG(LOG_DEBUG, "kex name (%s) used\n", KEX);
 	/*
 	 * Set the Cipher Suit(cs) as follows
 	 *

--- a/crypto/openssl/openssl_key_exchange_ecdh.c
+++ b/crypto/openssl/openssl_key_exchange_ecdh.c
@@ -157,8 +157,6 @@ static bool compute_publicBECDH(ecdh_context_t *key_ex_data)
 	uint16_t tmp = 0;
 	bool ret = false;
 
-	LOG(LOG_DEBUG, "compute_publicB started\n");
-
 	if (!key_ex_data) {
 		LOG(LOG_ERROR, "invalid param\n");
 		return ret;
@@ -298,7 +296,6 @@ static bool compute_publicBECDH(ecdh_context_t *key_ex_data)
 	}
 #endif
 	ret = true;
-	LOG(LOG_DEBUG, "compute_publicB complete\n");
 exit:
 	if (temp)
 		fdo_free(temp);

--- a/lib/fdo.c
+++ b/lib/fdo.c
@@ -310,6 +310,7 @@ static fdo_sdk_status app_initialize(void)
 	int32_t fsize;
 	int max_serviceinfo_sz;
 	char *buffer = NULL;
+	char *eptr = NULL;
 
 	if (!g_fdo_data)
 		return FDO_ERROR;
@@ -358,7 +359,12 @@ static fdo_sdk_status app_initialize(void)
 					(uint8_t *)buffer, fsize) == -1) {
 				LOG(LOG_ERROR, "Failed to read Manufacture DN\n");
 			}
-			max_serviceinfo_sz = atoi(buffer);
+			// set to 0 explicitly
+			errno = 0;
+			max_serviceinfo_sz = strtol(buffer, &eptr, 10);
+			if (!eptr || eptr == buffer || errno != 0) {
+				LOG(LOG_ERROR, "Invalid value read for maximum ServiceInfo size.\n");
+			}
 			if (max_serviceinfo_sz <= MIN_SERVICEINFO_SZ) {
 				max_serviceinfo_sz = MIN_SERVICEINFO_SZ;
 			}

--- a/lib/fdonet.c
+++ b/lib/fdonet.c
@@ -93,6 +93,7 @@ static bool get_netip_port(const char *proxydata, uint8_t proxydatsize,
 	char *pch = NULL;
 	uint8_t *proxy = NULL;
 	char proxy_url[40] = {0};
+	char *eptr = NULL;
 
 	ret =
 	    strstr_s((char *)proxydata, proxydatsize, "://", 3, (char **)&pch);
@@ -123,8 +124,15 @@ static bool get_netip_port(const char *proxydata, uint8_t proxydatsize,
 		goto err;
 	}
 
-	if (proxy[i] == ':')
-		*proxy_port = atoi((char *)&proxy[i + 1]);
+	if (proxy[i] == ':') {
+		// set to 0 explicitly
+		errno = 0;
+		*proxy_port = strtol((char *)&proxy[i + 1], &eptr, 10);
+		if (!eptr || eptr == (char *)&proxy[i+1] || errno != 0) {
+			LOG(LOG_ERROR, "Proxy Port read failed\n");
+			goto err;
+		}
+	}
 	ret = 0;
 err:
 	if (ip_list)

--- a/lib/fdotypes.c
+++ b/lib/fdotypes.c
@@ -1737,8 +1737,6 @@ bool fdo_rendezvous_read(fdor_t *fdor, fdo_rendezvous_t *rv)
 		return false;
 	}
 
-	LOG(LOG_DEBUG, "%s RendezvousInstr read started\n", __func__);
-
 	if (!fdor_start_array(fdor)) {
 		LOG(LOG_ERROR, "RendezvousInstr start array not found\n");
 		return false;
@@ -2037,7 +2035,6 @@ bool fdo_rendezvous_read(fdor_t *fdor, fdo_rendezvous_t *rv)
 		LOG(LOG_ERROR, "RendezvousInstr end array not found\n");
 		ret = false;
 	}
-	LOG(LOG_DEBUG, "%s RendezvousInstr read ended\n", __func__);
 
 	return ret;
 }
@@ -2097,8 +2094,6 @@ int fdo_rendezvous_directive_add(fdo_rendezvous_list_t *list,
 	if (list == NULL || directive == NULL)
 		return 0;
 
-	LOG(LOG_DEBUG, "Adding directive to rvlst\n");
-
 	if (list->num_rv_directives == 0) {
 		// List empty, add the first entry
 		list->rv_directives = directive;
@@ -2115,7 +2110,7 @@ int fdo_rendezvous_directive_add(fdo_rendezvous_list_t *list,
 		entry_ptr->next = directive;
 		list->num_rv_directives++;
 	}
-	LOG(LOG_DEBUG, "Added directive to rvlst, %d entries\n", list->num_rv_directives);
+	LOG(LOG_DEBUG, "Added RendezvousDirective entry %d\n", list->num_rv_directives);
 	return list->num_rv_directives;
 }
 
@@ -2129,8 +2124,6 @@ int fdo_rendezvous_list_add(fdo_rendezvous_directive_t *directives, fdo_rendezvo
 {
 	if (directives == NULL || rv == NULL)
 		return 0;
-
-	LOG(LOG_DEBUG, "Adding to rvlst\n");
 
 	if (directives->num_entries == 0) {
 		// List empty, add the first entry
@@ -2148,7 +2141,7 @@ int fdo_rendezvous_list_add(fdo_rendezvous_directive_t *directives, fdo_rendezvo
 		entry_ptr->next = rv;
 		directives->num_entries++;
 	}
-	LOG(LOG_DEBUG, "Added to rvlst, %d entries\n", directives->num_entries);
+	LOG(LOG_DEBUG, "Added RendezvousInstr entry %d\n", directives->num_entries);
 	return directives->num_entries;
 }
 
@@ -2282,8 +2275,6 @@ int fdo_rendezvous_list_read(fdor_t *fdor, fdo_rendezvous_list_t *list)
 
 			fdo_rendezvous_t *rv_entry = fdo_rendezvous_alloc();
 
-			LOG(LOG_DEBUG, "New rv allocated %p\n", (void *)rv_entry);
-
 			if (fdo_rendezvous_read(fdor, rv_entry))
 				fdo_rendezvous_list_add(rv_directive, rv_entry);
 			else {
@@ -2305,7 +2296,7 @@ int fdo_rendezvous_list_read(fdor_t *fdor, fdo_rendezvous_list_t *list)
 		return false;
 	}
 
-	LOG(LOG_DEBUG, "%s read\n", __func__);
+	LOG(LOG_DEBUG, "RendezvousInfo read completed\n");
 	return true;
 }
 

--- a/network/rest_interface.c
+++ b/network/rest_interface.c
@@ -399,6 +399,7 @@ bool get_rest_content_length(char *hdr, size_t hdrlen, uint32_t *cont_len)
 	char *rem, *p1, *p2;
 	size_t remlen;
 	char tmp[512];
+	char *eptr = NULL;
 	size_t tmplen;
 	int rcode, result_strcmpcase;
 
@@ -440,7 +441,13 @@ bool get_rest_content_length(char *hdr, size_t hdrlen, uint32_t *cont_len)
 			goto err;
 		}
 		*p1++ = 0;
-		rcode = atoi(p1);
+		// set to 0 explicitly
+		errno = 0;
+		rcode = strtol(p1, &eptr, 10);
+		if (!eptr || eptr == p1 || errno != 0) {
+			LOG(LOG_ERROR, "Invalid value read for Response Code\n");
+			goto err;
+		}
 		p2 = strchr(p1, ' ');
 		if (p2 == NULL) {
 			LOG(LOG_DEBUG, "Response code %03d\n", rcode);
@@ -490,7 +497,13 @@ bool get_rest_content_length(char *hdr, size_t hdrlen, uint32_t *cont_len)
 		if ((strcasecmp_s(tmp, tmplen, "content-length",
 				  &result_strcmpcase) == 0) &&
 		    result_strcmpcase == 0) {
-			rest->content_length = atoi(p1);
+			// set to 0 explicitly
+			errno = 0;
+			rest->content_length = strtol(p1, &eptr, 10);
+			if (!eptr || eptr == p1 || errno != 0) {
+				LOG(LOG_ERROR, "Invalid value read for Content-length\n");
+				goto err;
+			}
 			LOG(LOG_DEBUG, "Content-length: %zu\n",
 			    rest->content_length);
 		} else if ((strcasecmp_s(tmp, tmplen, "content-type",
@@ -531,7 +544,13 @@ bool get_rest_content_length(char *hdr, size_t hdrlen, uint32_t *cont_len)
 		} else if  (strcasecmp_s(tmp, tmplen, "message-type",
 					&result_strcmpcase) == 0 &&
 			   result_strcmpcase == 0) {
-			rest->msg_type = atoi(p1);
+			// set to 0 explicitly
+			errno = 0;
+			rest->msg_type = strtol(p1, &eptr, 10);
+			if (!eptr || eptr == p1 || errno != 0) {
+				LOG(LOG_ERROR, "Invalid value read for Message-Type\n");
+				goto err;
+			}
 			LOG(LOG_DEBUG, "Message-Type: %"PRIu32"\n",
 				rest->msg_type);
 		} else {


### PR DESCRIPTION
- Replaced atoi() usage with strtol() at places that are used currently.
Replacement in unused code will be done in further releases.
- Updated/Removed few debug logs.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>