### PR TITLE
Fix for issues in ServiceInfo parsing

### DIFF
--- a/device_modules/fdo_sys/fdo_sys.c
+++ b/device_modules/fdo_sys/fdo_sys.c
@@ -64,6 +64,14 @@ int fdo_sys(fdo_sdk_si_type type, fdor_t *fdor, char *module_message)
 				goto end;			
 			}
 
+			if (bin_len == 0) {
+#ifdef DEBUG_LOGS
+				printf("Empty value received for fdo_sys:filedesc\n");
+#endif
+				// received file name cannot be empty
+				return FDO_SI_CONTENT_ERROR;
+			}
+
 			bin_data = ModuleAlloc(bin_len * sizeof(uint8_t));
 			if (!bin_data) {
 #ifdef DEBUG_LOGS
@@ -109,7 +117,22 @@ int fdo_sys(fdo_sdk_si_type type, fdor_t *fdor, char *module_message)
 #endif
 				goto end;			
 			}
-			
+
+			if (bin_len == 0) {
+#ifdef DEBUG_LOGS
+				printf("Empty value received for fdo_sys:write\n");
+#endif
+				// received file content can be empty for an empty file
+				// do not allocate for the same and skip reading the entry
+				if (!fdor_next(fdor)) {
+#ifdef DEBUG_LOGS
+					printf("Failed to read fdo_sys:write\n");
+#endif
+					goto end;
+				}
+				return FDO_SI_SUCCESS;
+			}
+
 			bin_data = ModuleAlloc(bin_len * sizeof(uint8_t));
 			if (!bin_data) {
 #ifdef DEBUG_LOGS

--- a/device_modules/fdo_sys/sys_utils_linux.c
+++ b/device_modules/fdo_sys/sys_utils_linux.c
@@ -29,7 +29,7 @@ static bool is_valid_filename(const char *fname)
 		goto end;
 	}
 
-	if (strlastchar_s(filenme_woextension, 10, '.', &substring)) {
+	if (strlastchar_s(filenme_woextension, FILE_NAME_LEN, '.', &substring)) {
 		goto end;
 	}
 
@@ -73,6 +73,9 @@ end:
 
 void *ModuleAlloc(int size)
 {
+	if (size <= 0) {
+		return NULL;
+	}
 	void *buf = malloc(size);
 	if (!buf) {
 		printf("fdoAlloc failed to allocate\n");


### PR DESCRIPTION
- The file name of the received ServiceInfo script to be executed as per
the fdo_sys:exec command, was being parsed to find the dot character (.)
in the first 10 characters of the file name. Updated it use the full
filename length.
- Adding a check for empty content received for value of
fdo_sys:filedesc (invalid scenario, fail immediately) and
fdo_sys:write (valid scenario).

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>