### PR TITLE
Close file pointer when error occurs in unit-test

### DIFF
--- a/tests/unit/test_credentials.c
+++ b/tests/unit/test_credentials.c
@@ -252,6 +252,10 @@ static int32_t configure_blobs(void)
 		fclose(fp1);
 
 err:
+	if (fp1) {
+		fclose(fp1);
+		fp1 = NULL;
+	}
 	return -1;
 }
 


### PR DESCRIPTION
Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>