### PR TITLE
Change logging to use function name

### DIFF
--- a/lib/include/util.h
+++ b/lib/include/util.h
@@ -58,7 +58,7 @@ typedef enum log_level {
 	{                                                                      \
 		if (level <= LOG_LEVEL) {                                      \
 			if (level == LOG_ERROR) {                              \
-				printf("ERROR:[%s:%d] ", __FILE__, __LINE__);  \
+				printf("ERROR:[%s():%d] ", __func__, __LINE__);\
 			}                                                      \
 			if (level == LOG_DEBUG) {                              \
 				if (print_timestamp() != 0)                    \


### PR DESCRIPTION
Currently the filename is printed for LOG messages. The filename
contains the absolute path of the location of the current file in the
build system. This has the potential to leak some sensitive information
about the build system as part of the LOG messages.

Instead, passing the function name and the line number would provide
necessary information for debugging. This would also ensure that the LOG
messages would be same irrespective of the build system used.

Old error message:
ERROR:[/home/user/client-sdk-fidoiot/crypto/openssl/openssl_csr.c:138]
Failed to generate CSR data

New error message:
ERROR:[crypto_hal_get_device_csr():138] Failed to generate CSR data

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>