### PR TITLE
Updating handling of unsupported ServiceInfo modules

### DIFF
--- a/include/fdomodules.h
+++ b/include/fdomodules.h
@@ -22,6 +22,7 @@
 #endif
 
 #define FDO_MODULE_MESSAGE_ACTIVE "active"
+#define FDO_MODULE_SEPARATOR ":"
 
 /*==================================================================*/
 /* Service Info module registration functionality */

--- a/lib/fdo.c
+++ b/lib/fdo.c
@@ -273,6 +273,11 @@ static void fdo_protTO2Exit(app_data_t *app_data)
 	fdo_sv_info_clear_module_psi_osi_index(ps->sv_info_mod_list_head);
 	ps->total_dsi_rounds = 0;
 
+	if (ps->serviceinfo_invalid_modnames) {
+		fdo_serviceinfo_invalid_modname_free(ps->serviceinfo_invalid_modnames);
+		fdo_free(ps->serviceinfo_invalid_modnames);
+	}
+
 	// clear FDOR, FDOW and reset state to start of TO2
 	fdo_block_reset(&ps->fdor.b);
 	ps->fdor.have_block = false;

--- a/lib/fdoprot.c
+++ b/lib/fdoprot.c
@@ -297,9 +297,14 @@ bool fdo_prot_to2_init(fdo_prot_t *ps, fdo_service_info_t *si,
 			fdo_free(ps->dsi_info);
 			return false;
 		}
-	} else
+	} else {
 		LOG(LOG_DEBUG,
 		    "Sv_info: no modules are registered to the FDO!\n");
+	}
+	ps->device_serviceinfo_ismore = false;
+	ps->owner_serviceinfo_ismore = false;
+	ps->owner_serviceinfo_isdone = false;
+	ps->serviceinfo_invalid_modnames = NULL;
 
 	//	LOG(LOG_DEBUG, "Key Exchange Mode: %s\n", ps->kx->bytes);
 	//	LOG(LOG_DEBUG, "Cipher Suite: %s\n", ps->cs->bytes);

--- a/lib/include/fdoprot.h
+++ b/lib/include/fdoprot.h
@@ -156,10 +156,12 @@ typedef struct fdo_prot_s {
 	fdo_rendezvous_t *rv;
 	fdo_cose_t *to1d_cose;
 	uint16_t serv_req_info_num;
-	fdo_string_t *serviceinfo_invalid_modname;
+	fdo_sv_invalid_modnames_t *serviceinfo_invalid_modnames;
 	int maxOwnerServiceInfoSz;
 	int maxDeviceServiceInfoSz;
 	bool device_serviceinfo_ismore;
+	bool owner_serviceinfo_ismore;
+	bool owner_serviceinfo_isdone;
 	size_t prot_buff_sz;
 	int owner_supplied_service_info_num;
 	int owner_supplied_service_info_rcv;

--- a/lib/include/fdotypes.h
+++ b/lib/include/fdotypes.h
@@ -455,6 +455,12 @@ fdo_rendezvous_t *fdo_rendezvous_list_get(fdo_rendezvous_directive_t *list, int 
 int fdo_rendezvous_list_read(fdor_t *fdor, fdo_rendezvous_list_t *list);
 bool fdo_rendezvous_list_write(fdow_t *fdow, fdo_rendezvous_list_t *list);
 
+// List containing string of fixed length (FDO_MODULE_NAME_LEN)
+typedef struct fdo_sv_invalid_modnames_s {
+	char bytes[FDO_MODULE_NAME_LEN];
+	struct fdo_sv_invalid_modnames_s *next;
+} fdo_sv_invalid_modnames_t;
+
 typedef struct fdo_service_info_s {
 	int numKV;
 	fdo_key_value_t *kv;
@@ -512,9 +518,13 @@ void fdo_sv_info_clear_module_psi_osi_index(
     fdo_sdk_service_info_module_list_t *module_list);
 
 bool fdo_serviceinfo_read(fdor_t *fdor, fdo_sdk_service_info_module_list_t *module_list,
-	int *cb_return_val, fdo_string_t **serviceinfo_invalid_modname);
+	int *cb_return_val, fdo_sv_invalid_modnames_t **serviceinfo_invalid_modnames);
 bool fdo_supply_serviceinfoval(fdor_t *fdor, char *module_name, char *module_message,
 	fdo_sdk_service_info_module_list_t *module_list, int *cb_return_val);
+bool fdo_serviceinfo_invalid_modname_add(char *module_name,
+	fdo_sv_invalid_modnames_t **serviceinfo_invalid_modnames);
+void fdo_serviceinfo_invalid_modname_free(
+	fdo_sv_invalid_modnames_t *serviceinfo_invalid_modnames);
 
 bool fdo_compare_hashes(fdo_hash_t *hash1, fdo_hash_t *hash2);
 bool fdo_compare_byte_arrays(fdo_byte_array_t *ba1, fdo_byte_array_t *ba2);

--- a/tests/unit/test_fdotypes.c
+++ b/tests/unit/test_fdotypes.c
@@ -65,6 +65,7 @@ void test_fdo_service_info_add_kv_int(void);
 void test_fdo_service_info_add_kv_bool(void);
 void test_fdo_service_info_add_kv_bin(void);
 void test_fdo_service_info_add_kv(void);
+void test_fdo_serviceinfo_invalid_modname_add(void);
 void test_fdo_compare_hashes(void);
 void test_fdo_compare_byte_arrays(void);
 void test_fdo_compare_rvLists(void);
@@ -1470,6 +1471,33 @@ void test_fdo_service_info_add_kv(void)
 
 	ret = fdo_service_info_add_kv(&si, &kvs);
 	TEST_ASSERT_TRUE(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("_fdo_serviceinfo_invalid_modname_add", "[fdo_types][fdo]")
+#else
+void test_fdo_serviceinfo_invalid_modname_add(void)
+#endif
+{
+	bool ret = false;
+	fdo_sv_invalid_modnames_t *serviceinfo_invalid_modnames = NULL;
+
+	ret = fdo_serviceinfo_invalid_modname_add("testmod1", &serviceinfo_invalid_modnames);
+	TEST_ASSERT_TRUE(ret);
+	TEST_ASSERT_NOT_NULL(serviceinfo_invalid_modnames);
+
+	ret = fdo_serviceinfo_invalid_modname_add("testmod1", &serviceinfo_invalid_modnames);
+	TEST_ASSERT_TRUE(ret);
+	TEST_ASSERT_NOT_NULL(serviceinfo_invalid_modnames);
+
+	ret = fdo_serviceinfo_invalid_modname_add("testmod2", &serviceinfo_invalid_modnames);
+	TEST_ASSERT_TRUE(ret);
+	TEST_ASSERT_NOT_NULL(serviceinfo_invalid_modnames->next);
+
+	ret = fdo_serviceinfo_invalid_modname_add("testmod1", NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	fdo_serviceinfo_invalid_modname_free(serviceinfo_invalid_modnames);
 }
 
 #ifdef TARGET_OS_FREERTOS


### PR DESCRIPTION
- When Owner sends ServiceInfo instructions for an unsupported module,
the Device stores the module names in a list and responds back with the
following message when the Owner sends
TO2OwnerServiceInfo.ismoreServiceInfo as 'false':
ServiceInfo = [[[modname1:active, false],[modname2:active, false]..]]
where, modnameN is the received unsupported module name.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>