### PR TITLE
Update Device ServiceInfo processing and separate buffer size from MTU

### DIFF
--- a/app/main.c
+++ b/app/main.c
@@ -107,7 +107,7 @@ static fdo_sdk_service_info_module *fdo_sv_info_modules_init(void)
 {
 	fdo_sdk_service_info_module *module_info = NULL;
 
-	module_info = malloc(FDO_MAX_MODULES * (sizeof(*module_info)));
+	module_info = fdo_alloc(FDO_MAX_MODULES * (sizeof(fdo_sdk_service_info_module)));
 
 	if (!module_info) {
 		LOG(LOG_ERROR, "Malloc failed!\n");

--- a/lib/fdocred.c
+++ b/lib/fdocred.c
@@ -723,7 +723,6 @@ void fdo_owner_supplied_credentials_free(fdo_owner_supplied_credentials_t *osc)
 	if (osc != NULL) {
 		fdo_rendezvous_list_free(osc->rvlst);
 		osc->rvlst = NULL;
-		fdo_service_info_free(osc->si);
 		fdo_free(osc);
 	}
 }

--- a/lib/include/fdocred.h
+++ b/lib/include/fdocred.h
@@ -62,7 +62,6 @@ typedef struct FDOOwner_supplied_credentials_s {
 	fdo_rendezvous_list_t *rvlst;	// replacement RendezvousInfo
 	fdo_byte_array_t *guid;	// replacement GUID
 	fdo_public_key_t *pubkey;	// replacement PublicKey
-	fdo_service_info_t *si;
 } fdo_owner_supplied_credentials_t;
 
 fdo_owner_supplied_credentials_t *fdo_owner_supplied_credentials_alloc(void);

--- a/lib/include/fdoprot.h
+++ b/lib/include/fdoprot.h
@@ -107,9 +107,20 @@
 #define FDO_PROT_SPEC_VERSION 100
 
 // minimum ServiceInfo size
-#define MIN_SERVICEINFO_SZ 1300
+#define MIN_SERVICEINFO_SZ 256
 // maximum ServiceInfo size
 #define MAX_SERVICEINFO_SZ 8192
+// the margin considered while trying to fit Device ServiceInfo within MTU
+// which allows us to avoid sending more than the MTU at all times
+// For large numbers of ServiceInfoKeyVal to be sent, a larger number might be needed
+// However, the current implementation writes only 1 ServiceInfoKeyVal containing
+// any number of ServiceInfoKVs
+#define SERVICEINFO_MTU_FIT_MARGIN 30
+
+// minimum message buffer size to read/write protcol (DI/TO1/TO2)
+// if user-configured MAX_SERVICE_SZ is more than this, that is used as the buffer length
+// else this is used as the message buffer length
+#define MSG_BUFFER_SZ 1300
 // margin that gets added to either max or min ServiceInfo size to create
 // the final buffer to read/write protcol (DI/TO1/TO2)
 #define MSG_METADATA_SIZE 700

--- a/lib/include/fdotypes.h
+++ b/lib/include/fdotypes.h
@@ -462,8 +462,11 @@ typedef struct fdo_sv_invalid_modnames_s {
 } fdo_sv_invalid_modnames_t;
 
 typedef struct fdo_service_info_s {
-	int numKV;
+	size_t numKV;
 	fdo_key_value_t *kv;
+	size_t sv_index_end;
+	size_t sv_index_begin;
+	size_t sv_val_index;
 } fdo_service_info_t;
 
 fdo_service_info_t *fdo_service_info_alloc(void);
@@ -484,9 +487,10 @@ bool fdo_signature_verification(fdo_byte_array_t *plain_text,
 				fdo_byte_array_t *sg, fdo_public_key_t *pk);
 
 bool fdo_compare_public_keys(fdo_public_key_t *pk1, fdo_public_key_t *pk2);
-bool fdo_serviceinfo_write(fdow_t *fdow, fdo_service_info_t *si,
-				bool write_devmod_modules);
+bool fdo_serviceinfo_write(fdow_t *fdow, fdo_service_info_t *si);
+bool fdo_serviceinfo_kv_write(fdow_t *fdow, fdo_service_info_t *si, size_t num);
 bool fdo_serviceinfo_modules_list_write(fdow_t *fdow);
+bool fdo_serviceinfo_fit_mtu(fdow_t *fdow, fdo_service_info_t *si, size_t mtu);
 
 /*==================================================================*/
 /* Service Info functionality */

--- a/lib/prot/to2/msg67.c
+++ b/lib/prot/to2/msg67.c
@@ -81,14 +81,14 @@ int32_t msg67(fdo_prot_t *ps)
 
 	LOG(LOG_DEBUG, "TO2.OwnerServiceInfoReady: Received maxDeviceServiceInfoSz = %d\n",
 		rec_maxDeviceServiceInfoSz);
-	if (rec_maxDeviceServiceInfoSz <= MIN_SERVICEINFO_SZ) {
+	if (rec_maxDeviceServiceInfoSz < MIN_SERVICEINFO_SZ) {
 		// default to minimum and log it
 		ps->maxDeviceServiceInfoSz = MIN_SERVICEINFO_SZ;
 		LOG(LOG_DEBUG,
 			"TO2.OwnerServiceInfoReady: Received maxDeviceServiceInfoSz is less than "
 			"the minimum size supported. Defaulting to %d\n",
 			ps->maxDeviceServiceInfoSz);
-	} else if (rec_maxDeviceServiceInfoSz >= ps->maxDeviceServiceInfoSz) {
+	} else if (rec_maxDeviceServiceInfoSz > ps->maxDeviceServiceInfoSz) {
 		// nothing to do, just log it
 		LOG(LOG_DEBUG,
 			"TO2.OwnerServiceInfoReady: Received maxDeviceServiceInfoSz is more than "

--- a/lib/prot/to2/msg68.c
+++ b/lib/prot/to2/msg68.c
@@ -39,6 +39,7 @@ int32_t msg68(fdo_prot_t *ps)
 	fdo_service_info_t *serviceinfo_itr = NULL;
 	fdo_sv_invalid_modnames_t *serviceinfo_invalid_modnames_it = NULL;
 	char sv_modname_key[FDO_MODULE_NAME_LEN + FDO_MODULE_MSG_LEN + 1] = "";
+	size_t serviceinfo_invalid_modnames_count = 0;
 
 	if (!ps) {
 		LOG(LOG_ERROR, "Invalid protocol state\n");
@@ -46,6 +47,100 @@ int32_t msg68(fdo_prot_t *ps)
 	}
 
 	LOG(LOG_DEBUG, "TO2.DeviceServiceInfo started\n");
+
+	// DeviceServiceInfo's that need to be sent:
+	// 1. 'devmod' module (1st iteration)
+	// 2. Response [modname:active,false] when an unsupported module is being accessed.
+	// 3. External module(s) (remaining iterations) TO-DO later
+	// when multiple modules support will be added
+	// The current implementation only handle (1) and (2).
+
+	// either ther is something to send (calulate ismore), or nothing to send (ismore=false)
+	if (!ps->service_info && !ps->serviceinfo_invalid_modnames) {
+		ps->device_serviceinfo_ismore = false;
+	} else {
+		// There is a list of unsupported module names that need to be sent, AND,
+		// it has not been added to the serviceinfo list, AND,
+		// Owner has nothing more to send (for now), so that we only add once
+		if (!ps->service_info && ps->serviceinfo_invalid_modnames &&
+			!ps->owner_serviceinfo_ismore) {
+			ps->service_info = fdo_service_info_alloc();
+			if(!ps->service_info) {
+				LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to alloc ServiceInfo\n");
+				return false;
+			}
+
+			serviceinfo_invalid_modnames_it = ps->serviceinfo_invalid_modnames;
+			while (serviceinfo_invalid_modnames_it) {
+
+				// The message to be sent contains a list of unsupported module names
+				// with key/message 'active' and value 'false', something of the form
+				// [[modname1:active, false], [modname2:active, false]]...
+
+				// create 'modname:active'
+				if (0 != strncpy_s(sv_modname_key, FDO_MODULE_NAME_LEN,
+					serviceinfo_invalid_modnames_it->bytes, FDO_MODULE_NAME_LEN)) {
+					LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to concatenate module name\n");
+					goto err;
+				}
+				if (0 != strcat_s(sv_modname_key, FDO_MODULE_MSG_LEN,
+					FDO_MODULE_SEPARATOR)) {
+					LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to concatenate module name\n");
+					goto err;
+				}
+				if (0 != strcat_s(sv_modname_key, FDO_MODULE_MSG_LEN,
+					FDO_MODULE_MESSAGE_ACTIVE)) {
+					LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to concatenate module name\n");
+					goto err;
+				}
+
+				// add 'modname:active=false' into the serviceinfo list
+				if (!fdo_service_info_add_kv_bool(ps->service_info,
+					sv_modname_key, false)) {
+					LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to create ServiceInfo\n");
+					goto err;
+				}
+				serviceinfo_invalid_modnames_it = serviceinfo_invalid_modnames_it->next;
+				serviceinfo_invalid_modnames_count++;
+			}
+			ps->service_info->numKV = serviceinfo_invalid_modnames_count;
+
+			// clear it here immediately, so we don't use it back
+			fdo_serviceinfo_invalid_modname_free(ps->serviceinfo_invalid_modnames);
+			ps->serviceinfo_invalid_modnames = NULL;
+		}
+
+		// The splitting is done by considering an additional margin for CBOR encoding.
+		// The data is CBOR encoded twice. First time to find the what can be fit, and
+		// and second time to actually transmit the ServiceInfo.
+		// This is done in this way, since the underlying
+		// TinyCBOR library doesn't allow us to change the total number of entries
+		// in an array (ServiceInfoKeyVal, in this case), once it's set.
+		if (!fdo_serviceinfo_fit_mtu(&ps->fdow, ps->service_info,
+			ps->maxDeviceServiceInfoSz - SERVICEINFO_MTU_FIT_MARGIN)) {
+			LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to fit within MTU\n");
+			goto err;
+		}
+
+		if (ps->service_info->sv_index_end == ps->service_info->numKV &&
+			ps->service_info->sv_val_index == 0) {
+			ps->device_serviceinfo_ismore = false;
+		} else if (ps->service_info->sv_index_end < ps->service_info->numKV) {
+			ps->device_serviceinfo_ismore = true;
+		} else {
+			LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Invalid state reached while processing "
+				"Device ServiceInfo\n");
+			goto err;			
+		}
+	}
+
+	// reset FDOW because it was used in this method, out of place
+	fdo_block_reset(&ps->fdow.b);
+	ps->fdor.b.block_size = ps->prot_buff_sz;
+	if (!fdow_encoder_init(&ps->fdow)) {
+		LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to initialize FDOW encoder\n");
+		goto err;
+	}
 
 	/* send entry number to load */
 	fdow_next_block(&ps->fdow, FDO_TO2_GET_NEXT_OWNER_SERVICE_INFO);
@@ -55,89 +150,31 @@ int32_t msg68(fdo_prot_t *ps)
 		return false;
 	}
 
-	// DeviceServiceInfo's that need to be sent:
-	// 1. 'devmod' module (1st iteration)
-	// 2. Response [modname:active,false] when an unsupported module is being accessed.
-	// 3. External module(s) (remaining iterations) TO-DO later
-	// when multiple modules support will be added
-	// The current implementation only sends the 'devmod' module
+	// Send ServiceInfo only if:
+	// 1. We have ServiceInfo to send, AND
+	// 2. Owner has nothing more to send (for now atleast)
+	if (ps->service_info && !ps->owner_serviceinfo_ismore) {
 
-	// 1 for 'devmod' Device ServiceInfo
-	// however, it should contain total number of Device ServiceInfo rounds
-	ps->total_dsi_rounds = 1;
-	// since there is only 1 round-trip, isMoreServiceInfo is always false
-	ps->device_serviceinfo_ismore = false;
-
-	if (ps->service_info && ps->serv_req_info_num == 0) {
-
-		// for a single module and MIN_SERVICEINFO_SZ, only a single round-trip suffices
-		// TO-DO : To be updated when support for multiple Device ServiceInfo is added
 		if (!fdow_boolean(&ps->fdow, ps->device_serviceinfo_ismore)) {
 			LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to write IsMoreServiceInfo\n");
 			return false;
 		}
 
 		serviceinfo_itr = ps->service_info;
-		// Construct and write platform DSI's into a single msg
-		if (!fdo_serviceinfo_write(&ps->fdow, serviceinfo_itr, true)) {
+		// Construct and write Device ServiceInfo
+		if (!fdo_serviceinfo_write(&ps->fdow, serviceinfo_itr)) {
 			LOG(LOG_ERROR, "Error in combining platform DSI's!\n");
 			goto err;
 		}
-		// increment the internal counter that keeps track for Device ServiceInfo round-trips
-		// currently, only a single round-trip is done
-		ps->serv_req_info_num++;
+
 		serviceinfo_itr = NULL;
-
-	} else if (!ps->owner_serviceinfo_ismore && ps->serviceinfo_invalid_modnames) {
-		// 2. Response for unsuppprted modname
-		// The message to be sent contains a list of unsupported module names
-		// with key/message 'active' and value 'false', something of the form
-		// [[modname1:active, false], [modname2:active, false]]...
-		if (!fdow_boolean(&ps->fdow, ps->device_serviceinfo_ismore)) {
-			LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to write IsMoreServiceInfo\n");
-			return false;
+		// there is nothing to send, so clear it immediately
+		// so that we don't use it in the next iteration
+		if (!ps->device_serviceinfo_ismore) {
+			fdo_service_info_free(ps->service_info);
+			ps->service_info = NULL;
 		}
 
-		serviceinfo_itr = fdo_service_info_alloc();
-		if(!serviceinfo_itr) {
-			LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to alloc ServiceInfo\n");
-			return false;
-		}
-		serviceinfo_invalid_modnames_it = ps->serviceinfo_invalid_modnames;
-		while (serviceinfo_invalid_modnames_it) {
-
-			// create 'modname:active'
-			if (0 != strncpy_s(sv_modname_key, FDO_MODULE_NAME_LEN,
-				serviceinfo_invalid_modnames_it->bytes, FDO_MODULE_NAME_LEN)) {
-				LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to concatenate module name\n");
-				goto err;
-			}
-			if (0 != strcat_s(sv_modname_key, FDO_MODULE_MSG_LEN,
-				FDO_MODULE_SEPARATOR)) {
-				LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to concatenate module name\n");
-				goto err;
-			}
-			if (0 != strcat_s(sv_modname_key, FDO_MODULE_MSG_LEN,
-				FDO_MODULE_MESSAGE_ACTIVE)) {
-				LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to concatenate module name\n");
-				goto err;
-			}
-
-			// add 'modname:active=false' into the serviceinfo list
-			if (!fdo_service_info_add_kv_bool(serviceinfo_itr,
-				sv_modname_key, false)) {
-				LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to create ServiceInfo\n");
-				goto err;
-			}
-			serviceinfo_invalid_modnames_it = serviceinfo_invalid_modnames_it->next;
-		}
-		if (!fdo_serviceinfo_write(&ps->fdow, serviceinfo_itr, false)) {
-			LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to write ServiceInfo\n");
-			goto err;
-		}
-		// clear it here immediately, so we don't use it back in msg/69
-		fdo_serviceinfo_invalid_modname_free(ps->serviceinfo_invalid_modnames);
-		ps->serviceinfo_invalid_modnames = NULL;
 	} else {
 
 		// Empty ServiceInfo. send [false, []]
@@ -171,9 +208,5 @@ int32_t msg68(fdo_prot_t *ps)
 	ret = 0; /* Mark as success */
 	LOG(LOG_DEBUG, "TO2.DeviceServiceInfo completed successfully\n");
 err:
-	if (serviceinfo_itr) {
-		fdo_service_info_free(serviceinfo_itr);
-		serviceinfo_itr = NULL;
-	}
 	return ret;
 }


### PR DESCRIPTION
- Split the Device ServiceInfo (devmod + unsupported module list) based
on the MTU as specified by the Owner and supported by Device, and send
across multiple msg/68-69 iterations.
- The splitting is done by considering an additional margin for CBOR
encoding. The key-values are CBOR encoded once to decide how many
key-value pairs (partial/complete), can be fitted within the
current message as per MTU. Based on the findings, the ServiceInfo is
CBOR encoded again. This is done in this way, since the underlying
TinyCBOR library doesn't allow us to change the total number of entries
in an array (ServiceInfoKeyVal, in this case), once it's set. As result,
we find the total number of array entries first, by first round of CBOR
encoding + partial/complete key-value entries, and then do the 2nd round
of CBOR encoding.

- Additionally, lowering the range for ServiceInfo size from
[1300-8192] to [256-8192]. As a result, the protocol buffer size
has been separated from maximum ServiceInfo sizes, since the
minimum supported value (256 bytes)+margin,
may not be enough to send protocol messages.

- Fixing an issue in 'main.c' where 'malloc' was done instead of
'fdo_alloc' that caused random values to be present in the structure
allocated.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>