### PR TITLE
Fix: Use signed int API for Siginfo and memory leaks

### DIFF
--- a/lib/fdo.c
+++ b/lib/fdo.c
@@ -262,12 +262,14 @@ static void fdo_protTO2Exit(app_data_t *app_data)
 	}
 
 	/* clear Sv_info PSI/DSI/OSI related data */
+	fdo_sv_info_clear_module_psi_osi_index(ps->sv_info_mod_list_head);
+	ps->total_dsi_rounds = 0;
 	if (ps->dsi_info) {
 		ps->dsi_info->list_dsi = ps->sv_info_mod_list_head;
 		ps->dsi_info->module_dsi_index = 0;
+		fdo_free(ps->dsi_info);
+		ps->dsi_info = NULL;
 	}
-	fdo_sv_info_clear_module_psi_osi_index(ps->sv_info_mod_list_head);
-	ps->total_dsi_rounds = 0;
 
 	if (ps->serviceinfo_invalid_modnames) {
 		fdo_serviceinfo_invalid_modname_free(ps->serviceinfo_invalid_modnames);
@@ -281,6 +283,7 @@ static void fdo_protTO2Exit(app_data_t *app_data)
 	fdo_block_reset(&ps->fdow.b);
 	ps->fdow.b.block_size = ps->prot_buff_sz;
 	ps->state = FDO_STATE_T02_SND_HELLO_DEVICE;
+	fdo_kex_close();
 }
 
 /**

--- a/lib/fdoblockio.c
+++ b/lib/fdoblockio.c
@@ -142,6 +142,10 @@ bool fdow_encoder_init(fdow_t *fdow)
 	}
 	// if there's a current block, free and then alloc
 	if (fdow->current) {
+		while (fdow->current->previous) {
+			fdow->current = fdow->current->previous;
+			fdo_free(fdow->current->next);
+		}
 		fdo_free(fdow->current);
 	}
 	fdow->current = fdo_alloc(sizeof(fdow_cbor_encoder_t));
@@ -435,6 +439,10 @@ void fdow_flush(fdow_t *fdow)
 			fdo_free(fdob->block);
 		}
 		if (fdow->current) {
+			while (fdow->current->previous) {
+				fdow->current = fdow->current->previous;
+				fdo_free(fdow->current->next);
+			}
 			fdo_free(fdow->current);
 		}
 	}
@@ -484,6 +492,10 @@ bool fdor_parser_init(fdor_t *fdor) {
 	}
 	// if there's a current block, free and then alloc
 	if (fdor->current){
+		while (fdor->current->previous) {
+			fdor->current = fdor->current->previous;
+			fdo_free(fdor->current->next);
+		}
 		fdo_free(fdor->current);
 	}
 	fdor->current = fdo_alloc(sizeof(fdor_cbor_decoder_t));
@@ -850,6 +862,10 @@ void fdor_flush(fdor_t *fdor)
 			fdo_free(fdob->block);
 		}
 		if (fdor->current) {
+			while (fdor->current->previous) {
+				fdor->current = fdor->current->previous;
+				fdo_free(fdor->current->next);
+			}
 			fdo_free(fdor->current);
 		}
 	}

--- a/lib/fdotypes.c
+++ b/lib/fdotypes.c
@@ -493,7 +493,7 @@ bool fdo_siginfo_write(fdow_t *fdow)
 		LOG(LOG_ERROR, "SigInfo: Failed to start array\n");
 		return ret;
 	}
-	if (!fdow_unsigned_int(fdow, FDO_PK_ALGO)) {
+	if (!fdow_signed_int(fdow, FDO_PK_ALGO)) {
 		LOG(LOG_ERROR, "SigInfo: Failed to write sgType\n");
 		return ret;
 	}


### PR DESCRIPTION
- Use fdow_signed_int(), instead of fdow_unsigned_int() while creating
SigInfo.
- Fix certain memory leaks that occur in DI/TO1/TO2 failures.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>