### PR TITLE
Fix COSE unprotected header parsing

### DIFF
--- a/lib/fdoblockio.c
+++ b/lib/fdoblockio.c
@@ -510,7 +510,7 @@ bool fdor_parser_init(fdor_t *fdor) {
  * would be done using the newly created CborValue treating them as the items of this array.
  * The array needs to be closed using the method fdor_end_array().
  * 
- * @param fdor_t - struct fdow_t
+ * @param fdor_t - struct fdor_t
  * @return true if the operation was a success, false otherwise
  */
 bool fdor_start_array(fdor_t *fdor) {
@@ -543,7 +543,7 @@ bool fdor_start_array(fdor_t *fdor) {
  * would be done using the newly created CborValue treating them as the items of this map.
  * The map needs to be closed using the method fdor_end_map().
  * 
- * @param fdor_t - struct fdow_t
+ * @param fdor_t - struct fdor_t
  * @return true if the operation was a success, false otherwise
  */
 bool fdor_start_map(fdor_t *fdor) {
@@ -570,7 +570,7 @@ bool fdor_start_map(fdor_t *fdor) {
 /**
  * Store the number of items in the CBOR array (Major Type 4) into the supplied size_t variable.
  * 
- * @param fdor_t - struct fdow_t
+ * @param fdor_t - struct fdor_t
  * @param length - output variable where the array's number of items will be stored
  * @return true if the operation was a success, false otherwise
  */
@@ -589,9 +589,30 @@ bool fdor_array_length(fdor_t *fdor, size_t *length) {
 }
 
 /**
+ * Store the number of items in the CBOR map (Major Type 5) into the supplied size_t variable.
+ *
+ * @param fdor_t - struct fdor_t
+ * @param length - output variable where the array's number of items will be stored
+ * @return true if the operation was a success, false otherwise
+ */
+bool fdor_map_length(fdor_t *fdor, size_t *length) {
+	if (!fdor || !fdor->current || !length) {
+		LOG(LOG_ERROR, "CBOR decoder: Invalid params\n");
+		return false;
+	}
+	if (!cbor_value_is_map(&fdor->current->cbor_value) ||
+		cbor_value_get_map_length(&fdor->current->cbor_value,
+		length) != CborNoError) {
+		LOG(LOG_ERROR, "CBOR decoder: Failed to read length of Major Type 5 (map)\n");
+		return false;
+	}
+	return true;
+}
+
+/**
  * Store the CBOR bstr/tstr (Major Type 2/3) length into the supplied size_t variable.
  * 
- * @param fdor_t - struct fdow_t
+ * @param fdor_t - struct fdor_t
  * @param length - output variable where the string length will be stored
  * @return true if the operation was a success, false otherwise
  */
@@ -816,6 +837,25 @@ bool fdor_end_map(fdor_t *fdor) {
 	fdor->current = fdor->current->previous;
 	fdo_free(fdor->current->next);
 	return true;
+}
+
+/**
+ * Determine if the given buffer points to a map and whether it contains unread/unparsed
+ * elements (keys/values).
+ *
+ * @param fdor_t - struct fdor_t
+ * @return true if the map contains keys/values to be read/parsed, false otherwise
+ */
+bool fdor_map_has_more(fdor_t *fdor) {
+	if (!fdor || !fdor->current) {
+		LOG(LOG_ERROR, "CBOR decoder: Invalid params\n");
+		return false;
+	}
+	if (!cbor_value_is_map(&fdor->current->previous->cbor_value)) {
+		LOG(LOG_ERROR, "CBOR decoder: Not a map\n");
+		return false;
+	}
+	return !cbor_value_at_end(&fdor->current->cbor_value);
 }
 
 /**

--- a/lib/include/fdoblockio.h
+++ b/lib/include/fdoblockio.h
@@ -92,6 +92,7 @@ bool fdor_parser_init(fdor_t *fdor_cbor);
 bool fdor_start_array(fdor_t *fdor);
 bool fdor_start_map(fdor_t *fdor);
 bool fdor_array_length(fdor_t *fdor, size_t *length);
+bool fdor_map_length(fdor_t *fdor, size_t *length);
 bool fdor_string_length(fdor_t *fdor, size_t *length);
 bool fdor_byte_string(fdor_t *fdor, uint8_t *buffer, size_t buffer_length);
 bool fdor_text_string(fdor_t *fdor, char *buffer, size_t buffer_length);
@@ -102,6 +103,7 @@ bool fdor_unsigned_int(fdor_t *fdor, uint64_t *result);
 bool fdor_boolean(fdor_t *fdor, bool *result);
 bool fdor_end_array(fdor_t *fdor);
 bool fdor_end_map(fdor_t *fdor);
+bool fdor_map_has_more(fdor_t *fdor);
 bool fdor_next(fdor_t *fdor);
 void fdor_flush(fdor_t *fdor);
 

--- a/lib/include/fdotypes.h
+++ b/lib/include/fdotypes.h
@@ -242,7 +242,7 @@ typedef struct {
 	fdo_byte_array_t *payload;
 } fdo_cose_encrypt0_t;
 
-bool fdo_cose_encrypt0_free(fdo_cose_encrypt0_t *cose_encrypt0);
+void fdo_cose_encrypt0_free(fdo_cose_encrypt0_t *cose_encrypt0);
 fdo_cose_encrypt0_t* fdo_cose_encrypt0_alloc(void);
 bool fdo_cose_encrypt0_read_protected_header(fdor_t *fdor,
 	fdo_cose_encrypt0_protected_header_t *protected_header);
@@ -326,7 +326,7 @@ typedef struct {
 	fdo_byte_array_t *cose_signature;
 } fdo_cose_t;
 
-bool fdo_cose_free(fdo_cose_t *cose);
+void fdo_cose_free(fdo_cose_t *cose);
 bool fdo_cose_read_protected_header(fdor_t *fdor, fdo_cose_protected_header_t *cose_ph);
 bool fdo_cose_read_unprotected_header(fdor_t *fdor, fdo_cose_unprotected_header_t *cose_uph);
 bool fdo_cose_read(fdor_t *fdor, fdo_cose_t *cose, bool empty_uph);

--- a/tests/unit/test_fdotypes.c
+++ b/tests/unit/test_fdotypes.c
@@ -1147,6 +1147,10 @@ void test_fdo_cose_read(void)
 		fdor_flush(fdor);
 		fdo_free(fdor);
 	}
+	if (cose) {
+		fdo_cose_free(cose);
+		cose = NULL;
+	}
 }
 
 #ifdef TARGET_OS_FREERTOS


### PR DESCRIPTION
- Previously, the COSE unprotected header map was being parsed in an
ordered manner (entry1, entry2 and so on..). Update the parsing to read
the same map for the same elemnts in an iterative, un-ordered manner.
The header is only supposed to either contain 0 or 2 specific entries.
For any unknown entry, parsing would return an error.
NOTE: Similar parsing be done for other maps as well. However, as of
now, they only contain 1 single entry. So these are being parsed in an
ordered manner (unchanged for now). If more elements need to be parsed,
then those would need to be updated.

- Additionally, fix certain commenting issues, add few NULL checks and
remove unnecessary cose-free being done.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>