### PR TITLE
Add checks and zeroise certain buffers in TPM

### DIFF
--- a/crypto/openssl/tpm20_ECDSASignRoutines.c
+++ b/crypto/openssl/tpm20_ECDSASignRoutines.c
@@ -173,6 +173,9 @@ error:
 	if (pkey) {
 		EVP_PKEY_free(pkey);
 	}
+	if (eckey) {
+		EC_KEY_free(eckey);
+	}
 	if (sig) {
 		ECDSA_SIG_free(sig);
 	}


### PR DESCRIPTION
- Add checks for return values of certain TPM library methods.
- Zeroise some local variables.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>