### PR TITLE
Move new hmac key storage to msg/70 and devmod to TO2 init

### DIFF
--- a/cmake/blob_path.cmake
+++ b/cmake/blob_path.cmake
@@ -28,6 +28,8 @@ if(TARGET_OS MATCHES linux)
        -DTPM_OUTPUT_DATA_TEMP_FILE=\"${BLOB_PATH}/data/tpm_output_data_temp_file\"
        -DTPM_HMAC_PUB_KEY=\"${BLOB_PATH}/data/tpm_hmac_pub.key\"
        -DTPM_HMAC_PRIV_KEY=\"${BLOB_PATH}/data/tpm_hmac_priv.key\"
+       -DTPM_HMAC_REPLACEMENT_PUB_KEY=\"${BLOB_PATH}/data/tpm_hmac_replacement_pub.key\"
+       -DTPM_HMAC_REPLACEMENT_PRIV_KEY=\"${BLOB_PATH}/data/tpm_hmac_replacement_priv.key\"
        -DTPM_HMAC_DATA_PUB_KEY=\"${BLOB_PATH}/data/tpm_hmac_data_pub.key\"
        -DTPM_HMAC_DATA_PRIV_KEY=\"${BLOB_PATH}/data/tpm_hmac_data_priv.key\"
        -DTPM2_TSS_ENGINE_SO_PATH=\"/usr/local/lib/engines-1.1/libtpm2tss.so\"

--- a/crypto/common/fdoCryptoCommon.c
+++ b/crypto/common/fdoCryptoCommon.c
@@ -10,6 +10,7 @@
 #include "stdlib.h"
 #include "fdoCryptoCtx.h"
 #include "fdoCrypto.h"
+#include "tpm20_Utils.h"
 
 static fdo_crypto_context_t crypto_ctx;
 static void cleanup_ctx(void);
@@ -49,6 +50,15 @@ fdo_aes_keyset_t *get_keyset(void)
 fdo_byte_array_t **getOVKey(void)
 {
 	return &crypto_ctx.OVKey;
+}
+
+/**
+ * This function returns the address of Ownership voucher replacement hmac key.
+ * @return Byte array which holds the OV replacement hmac key
+ */
+fdo_byte_array_t **getreplacementOVKey(void)
+{
+	return &crypto_ctx.replacement_OVKey;
 }
 
 /**
@@ -102,6 +112,10 @@ int32_t fdo_crypto_close(void)
 	ret = crypto_close();
 	/* CLeanup of context structs */
 	cleanup_ctx();
+#if defined(DEVICE_TPM20_ENABLED)
+	/* clear the replacement hmac key objects */
+	fdo_tpm_clear_replacement_hmac_key();
+#endif
 	return ret;
 }
 
@@ -117,6 +131,10 @@ static void cleanup_ctx(void)
 	/* cleanup ovkey */
 	fdo_byte_array_free(crypto_ctx.OVKey);
 	crypto_ctx.OVKey = NULL;
+	if (crypto_ctx.replacement_OVKey) {
+		fdo_byte_array_free(crypto_ctx.replacement_OVKey);
+		crypto_ctx.replacement_OVKey = NULL;
+	}
 }
 
 /**

--- a/crypto/common/fdoHmac.c
+++ b/crypto/common/fdoHmac.c
@@ -101,6 +101,50 @@ err:
 }
 
 /**
+ * This function sets the Ownership Voucher replacement hmac key in the structure.
+ * Which will later be used to generate the replacement hmac.
+ * @param OVkey In Pointer to the Ownership Voucher replacement hmac key.
+ * @param OVKey_len In Size of the Ownership Voucher replacement hmac key
+ * @return 0 on success and -1 on failure.
+ */
+int32_t set_ov_replacement_key(fdo_byte_array_t *OVkey, size_t OVKey_len)
+{
+	int ret = -1;
+	fdo_byte_array_t **ovkeyctx = getreplacementOVKey();
+
+	if ((NULL == OVkey) || !(OVkey->bytes) ||
+	    !((BUFF_SIZE_32_BYTES == OVKey_len) ||
+	      (BUFF_SIZE_48_BYTES == OVKey_len))) {
+		return -1;
+	}
+
+	if (NULL == *ovkeyctx) {
+		*ovkeyctx = fdo_byte_array_alloc(OVKey_len);
+		if (!*ovkeyctx) {
+			LOG(LOG_ERROR, "Alloc failed\n");
+			return -1;
+		}
+	}
+	if (!(*ovkeyctx) || !(*ovkeyctx)->bytes) {
+		goto err;
+	}
+
+	ret = memcpy_s((*ovkeyctx)->bytes, OVKey_len, OVkey->bytes, OVKey_len);
+	if (ret != 0) {
+		ret = -1;
+		goto err;
+	}
+	ret = 0;
+err:
+	if ((0 != ret) && (*ovkeyctx)) {
+		fdo_byte_array_free(*ovkeyctx);
+		*ovkeyctx = NULL;
+	}
+
+	return ret;
+}
+
+/**
  * This function computes the HMAC of OV Header using device secret as the key
  * in
  * fdo_to2Crypto_ctx. The Ownership Voucher header shall be pointed by OVHdr
@@ -114,20 +158,39 @@ err:
  * operation is completed. This buffer must be allocated before calling this API
  * @param hmac_len In/Out In: Size of the buffer pointed to by hmac
  * Out: Size of the message hmac
+ * @param is_replacement_hmac In bool value that signifies whether the HMAC to
+ * be computed is the orginal HMAC (for DI, using original HMAC key), or,
+ * replacement HMAC (for TO2, using replacement HMAC key)
  * @return 0 on success and -1 on failure.
  */
 int32_t fdo_device_ov_hmac(uint8_t *OVHdr, size_t OVHdr_len, uint8_t *hmac,
-			   size_t hmac_len)
+			   size_t hmac_len, bool is_replacement_hmac)
 {
+	fdo_byte_array_t **keyset = NULL;
+
+	if (!OVHdr || !hmac) {
+		return -1;
+	}
+
+	if (is_replacement_hmac) {
+#if defined(DEVICE_TPM20_ENABLED)
+	return fdo_tpm_get_hmac(OVHdr, OVHdr_len, hmac, hmac_len,
+				TPM_HMAC_REPLACEMENT_PUB_KEY, TPM_HMAC_REPLACEMENT_PRIV_KEY);
+#else
+		keyset = getreplacementOVKey();
+#endif
+	} else {
 #if defined(DEVICE_TPM20_ENABLED)
 	return fdo_tpm_get_hmac(OVHdr, OVHdr_len, hmac, hmac_len,
 				TPM_HMAC_PUB_KEY, TPM_HMAC_PRIV_KEY);
 #else
-	fdo_byte_array_t **keyset = getOVKey();
-
-	if (!keyset || !*keyset || !OVHdr || !hmac) {
+		keyset = getOVKey();
+#endif
+	}
+	if (!keyset || !*keyset) {
 		return -1;
 	}
+
 	uint8_t *hmac_key = (*keyset)->bytes;
 	uint8_t hmac_key_len = (*keyset)->byte_sz;
 
@@ -143,7 +206,6 @@ int32_t fdo_device_ov_hmac(uint8_t *OVHdr, size_t OVHdr_len, uint8_t *hmac,
 	return 0;
 error:
 	return -1;
-#endif
 }
 
 /**
@@ -215,6 +277,88 @@ err:
 	fdo_byte_array_free(secret);
 #endif
 
+	return ret;
+}
+
+/**
+ * fdo_generate_ov_replacement_hmac_key function generates the new/replacement OV HMAC key
+ *
+ * @return
+ *        return 0 on success, -1 on failure.
+ */
+int32_t fdo_generate_ov_replacement_hmac_key(void)
+{
+
+	int32_t ret = -1;
+#if defined(DEVICE_TPM20_ENABLED)
+	if (0 !=
+	    fdo_tpm_generate_hmac_key(TPM_HMAC_REPLACEMENT_PUB_KEY,
+			TPM_HMAC_REPLACEMENT_PRIV_KEY)) {
+		LOG(LOG_ERROR, "Failed to generate device replacement HMAC key"
+			       " from TPM.\n");
+		return ret;
+	}
+
+	ret = 0;
+	LOG(LOG_DEBUG, "Successfully generated device HMAC key"
+		       " from TPM.\n");
+
+#else
+	fdo_byte_array_t *secret = fdo_byte_array_alloc(INITIAL_SECRET_BYTES);
+
+	if (!secret) {
+		LOG(LOG_ERROR, "Out of memory for OV replacement HMAC key\n");
+		goto err;
+	}
+
+	/* Generate replacement HMAC key for calcuating it over Ownership header */
+	fdo_crypto_random_bytes(secret->bytes, INITIAL_SECRET_BYTES);
+	if (0 != set_ov_replacement_key(secret, INITIAL_SECRET_BYTES)) {
+		goto err;
+	}
+
+	ret = 0;
+err:
+	fdo_byte_array_free(secret);
+#endif
+	return ret;
+}
+
+/**
+ * Commit the OV replacment key by replacing the original HMAC key
+ * with the replacement HMAC key. This operation is final and the original HMAC key
+ * is lost completely.
+ *
+ * @return
+ *        return 0 on success, -1 on failure.
+ */
+int32_t fdo_commit_ov_replacement_hmac_key(void)
+{
+
+	int32_t ret = -1;
+#if defined(DEVICE_TPM20_ENABLED)
+	if (0 != fdo_tpm_commit_replacement_hmac_key()) {
+		LOG(LOG_ERROR, "Failed to commit device replacement HMAC key"
+			       " for TPM.\n");
+		return ret;
+	}
+
+	ret = 0;
+#else
+	fdo_byte_array_t **secret = getreplacementOVKey();
+
+	if (!secret || !(*secret) || !(*secret)->bytes) {
+		LOG(LOG_ERROR, "Failed to read OV replacement HMAC key\n");
+		return false;
+	}
+
+	if (0 != set_ov_key(*secret, INITIAL_SECRET_BYTES)) {
+		LOG(LOG_ERROR, "Failed to commit OV replacement HMAC key\n");
+		return false;
+	}
+
+	ret = 0;
+#endif
 	return ret;
 }
 

--- a/crypto/include/fdoCrypto.h
+++ b/crypto/include/fdoCrypto.h
@@ -27,7 +27,10 @@ int32_t fdo_kex_close(void);
 fdo_string_t *fdo_get_device_kex_method(void);
 fdo_string_t *fdo_get_device_crypto_suite(void);
 fdo_byte_array_t **getOVKey(void);
+fdo_byte_array_t **getreplacementOVKey(void);
 int32_t set_ov_key(fdo_byte_array_t *OVkey, size_t OVKey_len);
+int32_t set_ov_replacement_key(fdo_byte_array_t *OVkey, size_t OVKey_len);
+int32_t fdo_commit_ov_replacement_hmac_key(void);
 int32_t fdo_ov_verify(uint8_t *message, uint32_t message_length,
 		      uint8_t *message_signature, uint32_t signature_length,
 		      fdo_public_key_t *pubkey, bool *result);
@@ -47,7 +50,7 @@ int32_t fdo_msg_decrypt(uint8_t *clear_text, uint32_t *clear_text_length,
 int32_t fdo_to2_hmac(uint8_t *to2Msg, size_t to2Msg_len, uint8_t *hmac,
 		     size_t hmac_len);
 int32_t fdo_device_ov_hmac(uint8_t *OVHdr, size_t OVHdr_len, uint8_t *hmac,
-			   size_t hmac_len);
+			   size_t hmac_len, bool is_replacement_hmac);
 int32_t fdo_crypto_hash(const uint8_t *message, size_t message_length,
 			uint8_t *hash, size_t hash_length);
 int32_t fdo_to2_chained_hmac(uint8_t *to2Msg, size_t to2Msg_len, uint8_t *hmac,
@@ -64,6 +67,7 @@ fdo_to2Sym_enc_ctx_t *get_fdo_to2_ctx(void);
 int32_t dev_attestation_init(void);
 void dev_attestation_close(void);
 int32_t fdo_generate_ov_hmac_key(void);
+int32_t fdo_generate_ov_replacement_hmac_key(void);
 int32_t fdo_compute_storage_hmac(const uint8_t *data, uint32_t data_length,
 				 uint8_t *computed_hmac,
 				 int computed_hmac_size);

--- a/crypto/include/fdoCryptoCtx.h
+++ b/crypto/include/fdoCryptoCtx.h
@@ -37,6 +37,7 @@ typedef struct {
 	fdo_to2Sym_enc_ctx_t to2Sym_enc;
 	fdo_kex_ctx_t kex;
 	fdo_byte_array_t *OVKey;
+	fdo_byte_array_t *replacement_OVKey;
 } fdo_crypto_context_t;
 
 fdo_aes_keyset_t *get_keyset(void);

--- a/crypto/include/tpm20_Utils.h
+++ b/crypto/include/tpm20_Utils.h
@@ -100,6 +100,8 @@ int32_t fdo_tpm_get_hmac(const uint8_t *data, size_t data_length, uint8_t *hmac,
 			 size_t hmac_length, char *tpmHMACPub_key,
 			 char *tpmHMACPriv_key);
 int32_t fdo_tpm_generate_hmac_key(char *tpmHMACPub_key, char *tpmHMACPriv_key);
+int32_t fdo_tpm_commit_replacement_hmac_key(void);
+void fdo_tpm_clear_replacement_hmac_key(void);
 int32_t is_valid_tpm_data_protection_key_present(void);
 
 #endif /* #ifndef __TPM20_UTILS_H__ */

--- a/lib/fdo.c
+++ b/lib/fdo.c
@@ -271,6 +271,11 @@ static void fdo_protTO2Exit(app_data_t *app_data)
 		ps->dsi_info = NULL;
 	}
 
+	if (ps->service_info) {
+		fdo_service_info_free(ps->service_info);
+		ps->service_info = NULL;
+	}
+
 	if (ps->serviceinfo_invalid_modnames) {
 		fdo_serviceinfo_invalid_modname_free(ps->serviceinfo_invalid_modnames);
 		fdo_free(ps->serviceinfo_invalid_modnames);
@@ -455,56 +460,6 @@ static fdo_sdk_status app_initialize(void)
 		return FDO_SUCCESS;
 	}
 
-	// Build up default 'devmod' ServiceInfo list
-	g_fdo_data->service_info = fdo_service_info_alloc();
-
-	if (!g_fdo_data->service_info) {
-		LOG(LOG_ERROR, "Service_info List allocation failed!\n");
-		return FDO_ERROR;
-	}
-
-	fdo_service_info_add_kv_bool(g_fdo_data->service_info, "devmod:active",
-				    true);
-	fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:os",
-				    OS_NAME);
-	fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:arch",
-				    ARCH);
-	fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:version",
-				    OS_VERSION);
-	fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:device",
-				    (char *)get_device_model());
-	fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:sn",
-				    (char *)get_device_serial_number());
-	fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:pathsep",
-				    PATH_SEPARATOR);
-	fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:sep",
-				    SEPARATOR);
-	fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:nl",
-				    NEWLINE);
-	fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:tmp",
-				    "");
-	fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:dir",
-				    "");
-	fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:progenv",
-				    PROGENV);
-	fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:bin",
-				    BIN_TYPE);
-	fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:mudurl",
-				    "");
-
-	// should ideally contain supported ServiceInfo module list and its count.
-	// for now, set this to 1, since we've only 1 module 'fdo_sys'
-	// TO-DO : Move this to fdotypes later when multiple Device ServiceInfo module
-	// support is added.
-	fdo_service_info_add_kv_int(g_fdo_data->service_info, "devmod:nummodules",
-			    	1);
-	fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:modules",
-				    g_fdo_data->module_list->module.module_name);
-
-	g_fdo_data->service_info->sv_index_begin = 0;
-	g_fdo_data->service_info->sv_index_end = 0;
-	g_fdo_data->service_info->sv_val_index = 0;
-
 	if (fdo_null_ipaddress(&g_fdo_data->prot.i1) == false) {
 		return FDO_ERROR;
 	}
@@ -594,6 +549,110 @@ void fdo_sdk_service_info_register_module(fdo_sdk_service_info_module *module)
 
 		list->next = new;
 	}
+}
+
+/**
+ * Create 'devmod' module and initialize it with the key-value pairs.
+ */
+static bool add_module_devmod(void) {
+	// Build up default 'devmod' ServiceInfo list
+	g_fdo_data->service_info = fdo_service_info_alloc();
+
+	if (!g_fdo_data->service_info) {
+		LOG(LOG_ERROR, "Service_info List allocation failed!\n");
+		return false;
+	}
+
+	if (!fdo_service_info_add_kv_bool(g_fdo_data->service_info, "devmod:active",
+				    true)) {
+		LOG(LOG_ERROR, "Failed to add devmod:active\n");
+		return false;
+	}
+	if (!fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:os",
+				    OS_NAME)) {
+		LOG(LOG_ERROR, "Failed to add devmod:os\n");
+		return false;
+	}
+	if (!fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:arch",
+				    ARCH)) {
+		LOG(LOG_ERROR, "Failed to add devmod:arch\n");
+		return false;
+	}
+	if (!fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:version",
+				    OS_VERSION)) {
+		LOG(LOG_ERROR, "Failed to add devmod:version\n");
+		return false;
+	}
+	if (!fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:device",
+				    (char *)get_device_model())) {
+		LOG(LOG_ERROR, "Failed to add devmod:device\n");
+		return false;
+	}
+	if (!fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:sn",
+				    (char *)get_device_serial_number())) {
+		LOG(LOG_ERROR, "Failed to add devmod:sn\n");
+		return false;
+	}
+	if (!fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:pathsep",
+				    PATH_SEPARATOR)) {
+		LOG(LOG_ERROR, "Failed to add devmod:pathsep\n");
+		return false;
+	}
+	if (!fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:sep",
+				    SEPARATOR)) {
+		LOG(LOG_ERROR, "Failed to add devmod:sep\n");
+		return false;
+	}
+	if (!fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:nl",
+				    NEWLINE)) {
+		LOG(LOG_ERROR, "Failed to add devmod:nl\n");
+		return false;
+	}
+	if (!fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:tmp",
+				    "")) {
+		LOG(LOG_ERROR, "Failed to add devmod:tmp\n");
+		return false;
+	}
+	if (!fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:dir",
+				    "")) {
+		LOG(LOG_ERROR, "Failed to add devmod:dir\n");
+		return false;
+	}
+	if (!fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:progenv",
+				    PROGENV)) {
+		LOG(LOG_ERROR, "Failed to add devmod:progenv\n");
+		return false;
+	}
+	if (!fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:bin",
+				    BIN_TYPE)) {
+		LOG(LOG_ERROR, "Failed to add devmod:bin\n");
+		return false;
+	}
+	if (!fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:mudurl",
+				    "")) {
+		LOG(LOG_ERROR, "Failed to add devmod:mudurl\n");
+		return false;
+	}
+
+	// should ideally contain supported ServiceInfo module list and its count.
+	// for now, set this to 1, since we've only 1 module 'fdo_sys'
+	// TO-DO : Move this to fdotypes later when multiple Device ServiceInfo module
+	// support is added.
+	if (!fdo_service_info_add_kv_int(g_fdo_data->service_info, "devmod:nummodules",
+					1)) {
+		LOG(LOG_ERROR, "Failed to add devmod:nummodules\n");
+		return false;
+	}
+	if (!fdo_service_info_add_kv_str(g_fdo_data->service_info, "devmod:modules",
+				    g_fdo_data->module_list->module.module_name)) {
+		LOG(LOG_ERROR, "Failed to add devmod:modules\n");
+		return false;
+	}
+
+	g_fdo_data->service_info->sv_index_begin = 0;
+	g_fdo_data->service_info->sv_index_end = 0;
+	g_fdo_data->service_info->sv_val_index = 0;
+	return true;
 }
 
 static fdo_sdk_service_info_module_list_t *
@@ -1223,6 +1282,11 @@ static bool _STATE_TO2(void)
 	ret = fdo_kex_init();
 	if (ret) {
 		LOG(LOG_ERROR, "Failed to initialize key exchange algorithm\n");
+		return FDO_ERROR;
+	}
+
+	if (!add_module_devmod()) {
+		LOG(LOG_ERROR, "Failed to create devmod module\n");
 		return FDO_ERROR;
 	}
 

--- a/lib/fdo.c
+++ b/lib/fdo.c
@@ -260,6 +260,10 @@ static void fdo_protTO2Exit(app_data_t *app_data)
 		fdo_byte_array_free(ps->nonce_to2setupdv_rcv);
 		ps->nonce_to2setupdv_rcv = NULL;
 	}
+	if (ps->new_ov_hdr_hmac) {
+		fdo_hash_free(ps->new_ov_hdr_hmac);
+		ps->new_ov_hdr_hmac = NULL;
+	}
 
 	/* clear Sv_info PSI/DSI/OSI related data */
 	fdo_sv_info_clear_module_psi_osi_index(ps->sv_info_mod_list_head);

--- a/lib/fdocred.c
+++ b/lib/fdocred.c
@@ -421,7 +421,7 @@ bool fdo_ov_hdr_hmac(fdo_ownership_voucher_t *ov, fdo_hash_t **hmac) {
 
 	if (0 != fdo_device_ov_hmac(fdow_hmac->b.block, fdow_hmac->b.block_size,
 				    (*hmac)->hash->bytes,
-				    (*hmac)->hash->byte_sz)) {
+				    (*hmac)->hash->byte_sz, false)) {
 		fdo_hash_free(*hmac);
 		LOG(LOG_ERROR, "Failed to generate OVHeaderHmac\n");
 		goto exit;
@@ -687,7 +687,7 @@ fdo_hash_t *fdo_new_ov_hdr_sign(fdo_dev_cred_t *dev_cred,
 
 	if (hmac &&
 	    (0 != fdo_device_ov_hmac(fdow->b.block, fdow->b.block_size,
-				     hmac->hash->bytes, hmac->hash->byte_sz))) {
+				     hmac->hash->bytes, hmac->hash->byte_sz, true))) {
 		fdo_hash_free(hmac);
 		goto exit;
 	}

--- a/lib/fdoprot.c
+++ b/lib/fdoprot.c
@@ -83,10 +83,6 @@ static void ps_free(fdo_prot_t *ps)
 		fdo_byte_array_free(ps->nonce_to2proveov_rcv);
 		ps->nonce_to2proveov_rcv = NULL;
 	}
-	if (ps->new_ov_hdr_hmac) {
-		fdo_hash_free(ps->new_ov_hdr_hmac);
-		ps->new_ov_hdr_hmac = NULL;
-	}
 	if (ps->nonce_to2provedv) {
 		fdo_byte_array_free(ps->nonce_to2provedv);
 		ps->nonce_to2provedv = NULL;
@@ -281,6 +277,9 @@ bool fdo_prot_to2_init(fdo_prot_t *ps, fdo_service_info_t *si,
 	/* Initialize svinfo related data */
 	if (module_list) {
 		ps->sv_info_mod_list_head = module_list;
+		if (!fdo_serviceinfo_deactivate_modules(ps->sv_info_mod_list_head)) {
+			return false;
+		}
 		ps->dsi_info = fdo_alloc(sizeof(fdo_sv_info_dsi_info_t));
 		if (!ps->dsi_info) {
 			return false;

--- a/lib/fdotypes.c
+++ b/lib/fdotypes.c
@@ -5227,6 +5227,24 @@ bool fdo_supply_serviceinfoval(fdor_t *fdor, char *module_name, char *module_mes
 }
 
 /**
+ * Deactivate all modules in the given module_list by setting 'active' to false.
+ *
+ * @param module_list - Owner ServiceInfo module list
+ */
+bool fdo_serviceinfo_deactivate_modules(fdo_sdk_service_info_module_list_t *module_list) {
+
+	if (!module_list) {
+		return false;
+	}
+	fdo_sdk_service_info_module_list_t *traverse_list = module_list;
+	while (traverse_list) {
+		traverse_list->module.active = false;
+		traverse_list = traverse_list->next;
+	}
+	return true;
+}
+
+/**
  * Allocate an empty fdo_service_info_t object.
  * @return an allocated fdo_service_info_t object.
  */

--- a/lib/include/fdotypes.h
+++ b/lib/include/fdotypes.h
@@ -535,6 +535,7 @@ bool fdo_serviceinfo_invalid_modname_add(char *module_name,
 	fdo_sv_invalid_modnames_t **serviceinfo_invalid_modnames);
 void fdo_serviceinfo_invalid_modname_free(
 	fdo_sv_invalid_modnames_t *serviceinfo_invalid_modnames);
+bool fdo_serviceinfo_deactivate_modules(fdo_sdk_service_info_module_list_t *module_list);
 
 bool fdo_compare_hashes(fdo_hash_t *hash1, fdo_hash_t *hash2);
 bool fdo_compare_byte_arrays(fdo_byte_array_t *ba1, fdo_byte_array_t *ba2);

--- a/lib/prot/to2/msg66.c
+++ b/lib/prot/to2/msg66.c
@@ -71,7 +71,7 @@ int32_t msg66(fdo_prot_t *ps)
 		if (resale_supported) {
 			LOG(LOG_DEBUG, "TO2.DeviceServiceInfoReady: *****Resale triggered.*****\n");
 			/* Generate new HMAC secret for OV header validation */
-			if (0 != fdo_generate_ov_hmac_key()) {
+			if (0 != fdo_generate_ov_replacement_hmac_key()) {
 				LOG(LOG_ERROR, "TO2.DeviceServiceInfoReady: Failed to refresh OV HMAC Key\n");
 				goto err;
 			}
@@ -127,5 +127,8 @@ int32_t msg66(fdo_prot_t *ps)
 	ret = 0; /* Mark as success */
 
 err:
+	if (hmac) {
+		fdo_hash_free(hmac);
+	}
 	return ret;
 }

--- a/lib/prot/to2/msg70.c
+++ b/lib/prot/to2/msg70.c
@@ -79,6 +79,17 @@ int32_t msg70(fdo_prot_t *ps)
 	}
 	LOG(LOG_DEBUG, "TO2.Done: Data protection key rotated successfully!!\n");
 
+	if (!ps->reuse_enabled) {
+		/* Commit the replacement hmac key only if reuse was not triggered*/
+		if (fdo_commit_ov_replacement_hmac_key() != 0) {
+			LOG(LOG_ERROR, "TO2.Done: Failed to store new device hmac key.\n");
+			goto err;
+		}
+		LOG(LOG_DEBUG, "TO2.Done: Updated device's new hmac key\n");
+	} else {
+		LOG(LOG_DEBUG, "TO2.Done: Device hmac key is unchanged as reuse was triggered.\n");
+	}
+
 	/* Write new device credentials */
 	if (store_credential(ps->dev_cred) != 0) {
 		LOG(LOG_ERROR, "TO2.Done: Failed to store new device creds\n");

--- a/tests/unit/test_cryptoSupport.c
+++ b/tests/unit/test_cryptoSupport.c
@@ -2831,7 +2831,7 @@ TEST_CASE("fdo_device_ov_hmac", "[crypto_support][fdo]")
 	TEST_ASSERT_EQUAL(0, ret);
 	ret = set_ov_key(OVkey, OVKey_len);
 	TEST_ASSERT_EQUAL(0, ret);
-	ret = fdo_device_ov_hmac(OVHdr, OVHdr_len, hmac, hmac_len);
+	ret = fdo_device_ov_hmac(OVHdr, OVHdr_len, hmac, hmac_len, false);
 	TEST_ASSERT_EQUAL(0, ret);
 
 	ret = fdo_kex_close();
@@ -2865,7 +2865,7 @@ TEST_CASE("fdo_device_ov_hmac_invalid_OVHdr", "[crypto_support][fdo]")
 	/* Negative test case */
 	ret = set_ov_key(OVkey, OVKey_len);
 	TEST_ASSERT_EQUAL(0, ret);
-	ret = fdo_device_ov_hmac(NULL, OVHdr_len, hmac, hmac_len);
+	ret = fdo_device_ov_hmac(NULL, OVHdr_len, hmac, hmac_len, false);
 	TEST_ASSERT_EQUAL(-1, ret);
 
 	fdo_hash_free(hmac1);
@@ -2897,7 +2897,7 @@ TEST_CASE("fdo_device_ov_hmac_invalid_OVHdr_len", "[crypto_support][fdo]")
 	/* Negative test case */
 	ret = set_ov_key(OVkey, OVKey_len);
 	TEST_ASSERT_EQUAL(0, ret);
-	ret = fdo_device_ov_hmac(OVHdr, 0, hmac, hmac_len);
+	ret = fdo_device_ov_hmac(OVHdr, 0, hmac, hmac_len, false);
 	TEST_ASSERT_EQUAL(-1, ret);
 
 	fdo_hash_free(hmac1);
@@ -2929,7 +2929,7 @@ TEST_CASE("fdo_device_ov_hmac_invalid_hmac", "[crypto_support][fdo]")
 	/* Negative test case */
 	ret = set_ov_key(OVkey, OVKey_len);
 	TEST_ASSERT_EQUAL(0, ret);
-	ret = fdo_device_ov_hmac(OVHdr, OVHdr_len, NULL, hmac_len);
+	ret = fdo_device_ov_hmac(OVHdr, OVHdr_len, NULL, hmac_len, false);
 	TEST_ASSERT_EQUAL(-1, ret);
 
 	fdo_hash_free(hmac1);
@@ -2961,7 +2961,7 @@ TEST_CASE("fdo_device_ov_hmac_invalid_hmac_len", "[crypto_support][fdo]")
 	/* Negative test case */
 	ret = set_ov_key(OVkey, OVKey_len);
 	TEST_ASSERT_EQUAL(0, ret);
-	ret = fdo_device_ov_hmac(OVHdr, OVHdr_len, hmac, 0);
+	ret = fdo_device_ov_hmac(OVHdr, OVHdr_len, hmac, 0, false);
 	TEST_ASSERT_EQUAL(-1, ret);
 
 	fdo_hash_free(hmac1);


### PR DESCRIPTION
- The replacement HMAC key as generated in msg/66 was also being
committed into internal memory, replacing the original HMAC key. This
caused the HMAC verification to fail in msg/61 in case TO2 was being
re-tried for the n'th (1-5) time. Instead of re-loading the same at TO2
init, created new methods to separate the current HMAC key and
replacement HMAC key, and only 'commit' replacement HMAC key at msg/70,
if reuse was not triggered (with reuse, it is never initialized). This
allows futher implementations to manage the replacement HMAC key in
their own way (for example, TPM stores different objects files, instead
of replacing the original).

- Move the 'devmod' allocation and key-value pais creation to TO2 init,
from app init. This fixes an issue wherein the 'devmod' was not being
sent in case initial TO2 failed after completion of msg/68 and
TO2 was being re-tried.

- Reset the active flag for every module during TO2 startup, thereby
deactivating it for next use.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>