### PR TITLE
Add certain checks at various situations and update usage

### DIFF
--- a/crypto/openssl/tpm20_ECDSASignRoutines.c
+++ b/crypto/openssl/tpm20_ECDSASignRoutines.c
@@ -168,6 +168,7 @@ int32_t crypto_hal_ecdsa_sign(const uint8_t *data, size_t data_len,
 error:
 	if (engine) {
 		ENGINE_finish(engine);
+		ENGINE_free(engine);
 		ENGINE_cleanup();
 	}
 	if (pkey) {

--- a/crypto/openssl/tpm20_Utils.c
+++ b/crypto/openssl/tpm20_Utils.c
@@ -623,7 +623,7 @@ static int32_t fdoTPMTSSContext_clean_up(ESYS_CONTEXT **esys_context,
 {
 	int ret = -1, is_failed = 0;
 	TSS2_TCTI_CONTEXT *tcti_context = NULL;
-	TSS2_RC rc;
+	TSS2_RC rc = TPM2_RC_FAILURE;
 
 	if (!esys_context || !*esys_context) {
 		LOG(LOG_ERROR, "Invalid parameter received.\n");

--- a/device_modules/fdo_sys/sys_utils_linux.c
+++ b/device_modules/fdo_sys/sys_utils_linux.c
@@ -194,15 +194,6 @@ bool process_data(fdoSysModMsg type, uint8_t *data, uint32_t data_len,
 #endif
 					goto end;
 				}
-					
-				// Executable permission for current user for the file
-				if (chmod(exec_token, 0700)) {
-#ifdef DEBUG_LOGS
-					printf("fdo_sys exec : Failed to set execute permission in %s\n",
-						file_name);
-#endif
-					goto end;
-				}
 			}
 			exec_token = strtok_s(NULL, &command_len,
 				space_delimeter_str, &exec_token_next);

--- a/lib/fdoprot.c
+++ b/lib/fdoprot.c
@@ -142,6 +142,9 @@ bool fdo_process_states(fdo_prot_t *ps)
 		 * it means that the data read from network is pending, so, we
 		 * read data and come back here for the same message processing
 		 */
+		if (!ps) {
+			return false;
+		}
 		prev_state = ps->state;
 
 		switch (ps->state) {

--- a/lib/include/util.h
+++ b/lib/include/util.h
@@ -127,20 +127,20 @@ void hexdump(const char *message, const void *buffer, size_t size);
 /* Print a non null-terminated buffer. */
 void print_buffer(int log_level, const uint8_t *buffer, size_t length);
 
-/// Read a buffer from content of a file
+/// Read a buffer from content of a file. The buffer returned is non NULL-terminated.
 /*!
   \param[in] filename
   The file path.
   \param[in] buffer
   The buffer to be filled.
-  \param[out] size
+  \param[in] size
   The allocated size of the buffer in bytes.
 
   \returns
   0 on successful read, -1 on error.
 
 */
-int read_buffer_from_file(const char *filename, void *buffer, size_t size);
+int read_buffer_from_file(const char *filename, uint8_t *buffer, size_t size);
 
 /*
  * Allocate a buffer and set its contents to 0 before using it.

--- a/network/include/rest_interface.h
+++ b/network/include/rest_interface.h
@@ -27,6 +27,8 @@
 #define IP_TAG_LEN 16   // e.g. 192.168.111.111
 #define MAX_PORT_SIZE 6 // max port size is 65536 + 1null char
 
+#define ISASCII(ch) ((ch & ~0x7f) == 0)
+
 // REST context
 typedef struct Rest_ctx_s {
 	uint32_t prot_ver;

--- a/network/network_if_linux.c
+++ b/network/network_if_linux.c
@@ -71,6 +71,11 @@ static bool read_until_new_line(fdo_con_handle handle, char *out, size_t size,
 		}
 		if (sz < size) {
 			out[sz++] = c;
+		} else {
+			// error out even if no new-line is encountered
+			// if the sz grows larger than size
+			LOG(LOG_ERROR, "Exceeded expected size while reading socket\n");
+			return false;
 		}
 
 		if (c == '\n') {

--- a/network/rest_interface.c
+++ b/network/rest_interface.c
@@ -420,6 +420,7 @@ bool get_rest_content_length(char *hdr, size_t hdrlen, uint32_t *cont_len)
 	size_t tmplen = 0;
 	long rcode = 0;
 	int result_strcmpcase = 0;
+	size_t counter = 0;
 
 	/* REST context must be active */
 	if (!isRESTContext_active()) {
@@ -432,6 +433,12 @@ bool get_rest_content_length(char *hdr, size_t hdrlen, uint32_t *cont_len)
 		goto err;
 	}
 
+	for (counter = 0; counter < hdrlen; counter ++) {
+		if (!ISASCII(hdr[counter])) {
+			LOG(LOG_ERROR, "Header contains non-ASCII values\n");
+			goto err;
+		}
+	}
 	rest->msg_type = 0;
 
 	// GET HTTP reponse from header

--- a/storage/util.c
+++ b/storage/util.c
@@ -58,7 +58,7 @@ size_t get_file_size(char const *filename)
 /**
  * Internal API
  */
-int read_buffer_from_file(const char *filename, void *buffer, size_t size)
+int read_buffer_from_file(const char *filename, uint8_t *buffer, size_t size)
 {
 	FILE *file = NULL;
 	size_t bytes_read = 0;


### PR DESCRIPTION
- Use fopen in 'wx' mode while writing ownership_transfer file.
- Check whether the received header characters are ASCII before using
them.
- Break out of the endless loop in case the 'sz' becomes more than the
expected 'size' while reading REST header character-by-character.
- Add NULL check before using 'ps' in 'fdo_process_states'.
- Using uint8_t* as buffer type, versus the previous 'void*', to avoid
confusion about the buffer usage.
- Removed 'chmod +x' on file from fdo_sys:exec processing, because
the command is expected to be executed without providing extra
permissions to it.
- Initializing 'TSS2_RC' return code and freeing 'engine' referance as
suggested in the API documentation.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>