### PR TITLE
Process RVDELAYSEC during retry and update retry scenario

### DIFF
--- a/lib/fdoprotctx.c
+++ b/lib/fdoprotctx.c
@@ -101,7 +101,6 @@ void fdo_prot_ctx_free(fdo_prot_ctx_t *prot_ctx)
 		if (prot_ctx->host_ip) {
 			fdo_free(prot_ctx->host_ip);
 		}
-		fdo_free(prot_ctx);
 	}
 }
 

--- a/tests/unit/test_protctx.c
+++ b/tests/unit/test_protctx.c
@@ -158,12 +158,14 @@ TEST_CASE("fdo_prot_ctx_alloc", "[protctx][fdo]")
 				      host_dns, host_port, false);
 	TEST_ASSERT_NOT_NULL(prot_ctx);
 	fdo_prot_ctx_free(prot_ctx);
+	fdo_free(prot_ctx);
 
 	// positive test case, prot_ctx is allocated
 	prot_ctx = fdo_prot_ctx_alloc(&fdo_prot_dummy, &protdata, NULL,
 				      host_dns, host_port, true);
 	TEST_ASSERT_NOT_NULL(prot_ctx);
 	fdo_prot_ctx_free(prot_ctx);
+	fdo_free(prot_ctx);
 
 	g_malloc_fail = true;
 	prot_ctx = fdo_prot_ctx_alloc(&fdo_prot_dummy, &protdata, NULL,


### PR DESCRIPTION
- Process RVDELAYSEC to use during subsequent retries as the delay
interval. If no RVDELAY is specified, or if value 0 is specified,
then default delay of '3' seconds is chosen before retrying next
RendezvousDirective, or '120' seconds is chosen before retrying
the RendezvousInfo from the start. Max delay is '3600' seconds.

- Fixing an issue where retry (5 times) was not being done completely
for all RendezvousDirectives. Fixed by returning 'true', if the there
are more RendezvousDirectives to be iterated over, or 'false', if there
are no more RendezvousDirectives left in STATE_TO1 and STATE_TO2
methods. The basic idea is that the intermediate RendezvousDirectives in
the RendezvousInfo would return 'false' in case of failures, and, the
final/leaf RendezvousDirective would return 'true' in case of failure.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>