### PR TITLE
Fix test-cases: Use fdo_alloc and proper-sized input

### DIFF
--- a/tests/unit/test_cryptoSupport.c
+++ b/tests/unit/test_cryptoSupport.c
@@ -23,8 +23,8 @@
 #define DER_PUBKEY_LEN_MAX 512
 #define ECDSA_PK_MAX_LENGTH 200
 
-static uint8_t test_buff1[] = {1, 2, 3, 4, 5};
-static uint8_t test_buff2[] = {6, 7, 8, 9, 10};
+static uint8_t test_buff1[] = {1, 2, 3, 4, 5, 6, 7, 8};
+static uint8_t test_buff2[] = {6, 7, 8, 9, 10, 9, 8, 7};
 
 uint8_t pub_key[] = {
     0x00, 0x00, 0x00, 0x0d, 0xdd, 0xdd, 0xcc, 0xcc, 0x00, 0x00, 0x00, 0x00,
@@ -149,8 +149,8 @@ static EC_KEY *Private_key(void);
 
 /*** Function Definitions ***/
 
-static uint8_t key1[] = "test-key";
-static uint8_t key2[] = "key-test";
+static uint8_t key1[] = "testkey";
+static uint8_t key2[] = "keytest";
 
 static uint8_t *get_randomiv(void)
 {

--- a/tests/unit/test_hal_os.c
+++ b/tests/unit/test_hal_os.c
@@ -264,7 +264,7 @@ TEST_CASE("read_until_new_line", "[OS][HAL][fdo]")
 	bool retval;
 	struct fdo_sock_handle handle = {0};
 
-	fdo_prot_ctx_t *prot_ctx = malloc(sizeof(fdo_prot_ctx_t));
+	fdo_prot_ctx_t *prot_ctx = fdo_alloc(sizeof(fdo_prot_ctx_t));
 	TEST_ASSERT_NOT_NULL(prot_ctx);
 	ret = memset_s(prot_ctx, sizeof(fdo_prot_ctx_t), 0);
 	TEST_ASSERT_EQUAL_INT(0, ret);

--- a/tests/unit/test_protctx.c
+++ b/tests/unit/test_protctx.c
@@ -212,16 +212,16 @@ TEST_CASE("fdo_prot_ctx_run", "[protctx][fdo]")
 	char host_dns[] = "localhost";
 	uint16_t host_port = 5000;
 
-	fdo_prot_ctx_t *prot_ctx = malloc(sizeof(fdo_prot_ctx_t));
+	fdo_prot_ctx_t *prot_ctx = fdo_alloc(sizeof(fdo_prot_ctx_t));
 	TEST_ASSERT_NOT_NULL(prot_ctx);
 
 	ret = memset_s(prot_ctx, sizeof(fdo_prot_ctx_t), 0);
 	TEST_ASSERT_EQUAL_INT(0, ret);
 
-	prot_ctx->host_ip = malloc(sizeof(fdo_ip_address_t));
+	prot_ctx->host_ip = fdo_alloc(sizeof(fdo_ip_address_t));
 	TEST_ASSERT_NOT_NULL(prot_ctx->host_ip);
 
-	prot_ctx->protdata = malloc(sizeof(fdo_prot_t));
+	prot_ctx->protdata = fdo_alloc(sizeof(fdo_prot_t));
 	TEST_ASSERT_NOT_NULL(prot_ctx->protdata);
 
 	prot_ctx->sock_hdl = FDO_CON_INVALID_HANDLE;


### PR DESCRIPTION
Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>