### PR TITLE
Remove unsupported EC384 curve-based parameters

### DIFF
--- a/crypto/include/tpm20_Utils.h
+++ b/crypto/include/tpm20_Utils.h
@@ -13,11 +13,7 @@
 #define TPM_HMAC_PRIV_KEY_CONTEXT_SIZE_160 160
 #define TPM_HMAC_PUB_KEY_CONTEXT_SIZE 48
 
-#if defined(ECDSA256_DA)
 #define FDO_TPM2_CURVE_ID TPM2_ECC_NIST_P256
-#else
-#define FDO_TPM2_CURVE_ID TPM2_ECC_NIST_P384
-#endif
 
 #define TPM2_ZEROISE_FREE(ref)                                                 \
 	{                                                                      \

--- a/docs/tpm.md
+++ b/docs/tpm.md
@@ -147,6 +147,8 @@ make -j$(nproc)
 Several other options to choose when building the device are, but not limited to, the following: device-attestation (DA) methods, Advanced Encryption Standard (AES) encryption modes (AES_MODE), and underlying cryptography library to use (TLS).
 Refer to the section [FDO Build configurations](build_conf.md)
 
+> ***NOTE***: Currently, only Elliptic-Curve (EC) cryptography keys based on `NIST P-256` or `secp256r1` are supported for TPM* enabled FDO Client SDK due to limitations on testing with the available hardware that does not support keys based on `NIST P-384`. Consequently, this configuration only supports usage of 128-bit key for AES operations (GCM/CCM) and generates 256-bit HMAC.
+
 <a name="run_linux_fdo"></a>
 
 ## 7. Running the Application <!-- Ensuring generic updates are captured where applicable -->

--- a/utils/tpm_make_ready_ecdsa.sh
+++ b/utils/tpm_make_ready_ecdsa.sh
@@ -14,21 +14,8 @@ primary_key_type="ecc256:aes128cfb"
 
 usage() 
 {
-    echo "Usage: $0 -p <path of the parent to C-Device data directory> [-v verbose] [-c nist_p256/nist_p384, default:nist_p256] [-i use /dev/tpmrm0 as Resource Manager, if not provided TPM2-ABRMD will be used]"
+    echo "Usage: $0 -p <path of the parent to C-Device data directory> [-v verbose] [-i use /dev/tpmrm0 as Resource Manager, if not provided TPM2-ABRMD will be used]"
     exit 2
-}
-
-check_curve()
-{
-    if [ $curve != "nist_p256" ] && [ $curve != "nist_p384" ]; then
-        echo "Invalid Curve option: $curve"
-        exit 2
-    fi
-    if [ $curve == "nist_p384" ]; then
-        echo "Device Keytype updated to 14 and curve updated to $curve".
-        DEVICE_MSTRING_KEYTYPE=14
-        primary_key_type="ecc384:aes128cfb"
-    fi
 }
 
 parse_args() 
@@ -41,9 +28,6 @@ parse_args()
         case ${opt} in
             p ) found_path=1;
                 PARENT_DIR=$OPTARG
-              ;;
-            c ) curve=$OPTARG;
-                check_curve                
               ;;
             i ) export TPM2TOOLS_TCTI="device:/dev/tpmrm0"
               ;;


### PR DESCRIPTION
- Remove EC384 curve-based configuration from header file and the
script. Update README for the same.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>