### PR TITLE
Return error on empty fdo_sys:exec and few minor updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ include(cmake/blob_path.cmake)
 
 
 if (NOT(DEFINED ENV{SAFESTRING_ROOT}))
-  message(FATAL_ERROR "SAFESTING_ROOT not set")
+  message(FATAL_ERROR "SAFESTRING_ROOT not set")
 endif()
 
 if (NOT(DEFINED ENV{TINYCBOR_ROOT}))

--- a/device_modules/fdo_sys/fdo_sys.c
+++ b/device_modules/fdo_sys/fdo_sys.c
@@ -155,7 +155,7 @@ int fdo_sys(fdo_sdk_si_type type, fdor_t *fdor, char *module_message)
 
 			if (!process_data(FDO_SYS_MOD_MSG_WRITE, bin_data, bin_len, filename)) {
 #ifdef DEBUG_LOGS
-				printf("Failed to process value for fdo_sys:write");
+				printf("Failed to process value for fdo_sys:write\n");
 #endif
 				goto end;
 			}
@@ -182,6 +182,15 @@ int fdo_sys(fdo_sdk_si_type type, fdor_t *fdor, char *module_message)
 #ifdef DEBUG_LOGS
 				printf("Failed to read fdo_sys:exec array length\n");
 #endif
+				goto end;
+			}
+
+			if (exec_array_length == 0) {
+#ifdef DEBUG_LOGS
+				printf("Empty array received for fdo_sys:exec\n");
+#endif
+				// received exec array cannot be empty
+				result = FDO_SI_CONTENT_ERROR;
 				goto end;
 			}
 

--- a/device_modules/fdo_sys/sys_utils_linux.c
+++ b/device_modules/fdo_sys/sys_utils_linux.c
@@ -52,7 +52,7 @@ static bool is_valid_filename(const char *fname)
 	for (i = 0; i < (sizeof(whitelisted) / sizeof(whitelisted[0])); i++) {
 		ext_len = strnlen_s(substring, EXT_MAX_LEN);
 		if (!ext_len || ext_len == EXT_MAX_LEN) {
-			printf("Couldn't find file extension");
+			printf("Couldn't find file extension\n");
 			ret = false;
 			break;
 		}
@@ -123,7 +123,7 @@ bool process_data(fdoSysModMsg type, uint8_t *data, uint32_t data_len,
 
 	if (!data || !data_len) {
 #ifdef DEBUG_LOGS
-		printf("NULL params in Process_data");
+		printf("NULL params in Process_data\n");
 #endif
 		return false;
 	}
@@ -131,6 +131,12 @@ bool process_data(fdoSysModMsg type, uint8_t *data, uint32_t data_len,
 	// For writing to a file
 	if (type == FDO_SYS_MOD_MSG_WRITE) {
 
+		if (!file_name) {
+#ifdef DEBUG_LOGS
+			printf("fdo_sys write:No filename present\n");
+#endif
+			return false;
+		}
 		fp = fopen(file_name, "a");
 		if (!fp) {
 #ifdef DEBUG_LOGS
@@ -145,7 +151,7 @@ bool process_data(fdoSysModMsg type, uint8_t *data, uint32_t data_len,
 		if (fwrite(data, sizeof(char), data_len, fp) !=
 		    (size_t)data_len) {
 #ifdef DEBUG_LOGS
-			printf("fdo_sys write: Failed to write");
+			printf("fdo_sys write: Failed to write\n");
 #endif
 			goto end;
 		}

--- a/lib/fdo.c
+++ b/lib/fdo.c
@@ -1070,9 +1070,10 @@ static bool _STATE_DI(void)
 	if (fdo_prot_ctx_run(prot_ctx) != 0) {
 		LOG(LOG_ERROR, "DI failed.\n");
 		if (g_fdo_data->error_recovery) {
-			LOG(LOG_INFO, "Retrying.....\n");
 			g_fdo_data->state_fn = &_STATE_DI;
+			LOG(LOG_INFO, "\nDelaying for %"PRIu64" seconds\n\n", g_fdo_data->delaysec);
 			fdo_sleep(g_fdo_data->delaysec);
+			LOG(LOG_INFO, "Retrying.....\n");
 			goto end;
 		} else {
 			ERROR()
@@ -1206,6 +1207,7 @@ static bool _STATE_TO1(void)
 				}
 			} else if (rv->delaysec) {
 				g_fdo_data->delaysec = *rv->delaysec;
+				LOG(LOG_INFO, "DelaySec set, Delay: %"PRIu64"s\n", g_fdo_data->delaysec);
 			}
 			// ignore the other RendezvousInstr as they are not used for making requests
 			rv = rv->next;
@@ -1251,6 +1253,7 @@ static bool _STATE_TO1(void)
 				if (g_fdo_data->delaysec == 0 || g_fdo_data->delaysec > max_delay) {
 					g_fdo_data->delaysec = default_delay;
 				}
+				LOG(LOG_INFO, "\nDelaying for %"PRIu64" seconds\n\n", g_fdo_data->delaysec);
 				fdo_sleep(g_fdo_data->delaysec);
 				continue;
 			}
@@ -1262,11 +1265,12 @@ static bool _STATE_TO1(void)
 				if (g_fdo_data->delaysec == 0 || g_fdo_data->delaysec > max_delay) {
 					g_fdo_data->delaysec = default_delay_rvinfo_retries;
 				}
-				LOG(LOG_INFO, "Retrying.....\n");
+				LOG(LOG_INFO, "\nDelaying for %"PRIu64" seconds\n\n", g_fdo_data->delaysec);
 				g_fdo_data->state_fn = &_STATE_TO1;
+				LOG(LOG_INFO, "Retrying.....\n");
 				return ret;
 			} else {
-				LOG(LOG_INFO, "Retry is diabled. Aborting.....\n");
+				LOG(LOG_INFO, "Retry is disabled. Aborting.....\n");
 				return ret;
 			}
 		} else {
@@ -1380,6 +1384,7 @@ static bool _STATE_TO2(void)
 					}
 				} else if (rv->delaysec) {
 					g_fdo_data->delaysec = *rv->delaysec;
+					LOG(LOG_INFO, "DelaySec set, Delay: %"PRIu64"s\n", g_fdo_data->delaysec);
 				}
 				// no need to check for RVBYPASS here again, since we used it
 				// to get here in the first place
@@ -1469,6 +1474,7 @@ static bool _STATE_TO2(void)
 			if (!rvbypass) {
 				fdo_free(ip);
 				ip = NULL;
+				LOG(LOG_INFO, "\nDelaying for %"PRIu64" seconds\n\n", default_delay);
 				fdo_sleep(default_delay);
 				// if there is another Owner location present, try it
 				// the execution reaches here only if rvbypass was never set
@@ -1493,6 +1499,7 @@ static bool _STATE_TO2(void)
 						g_fdo_data->delaysec = default_delay;
 					}
 				}
+				LOG(LOG_INFO, "\nDelaying for %"PRIu64" seconds\n\n", g_fdo_data->delaysec);
 			}
 			// if this is last directive (NULL), return false to mark end of 1 retry
 			// else if there are more directives left, return true for trying those


### PR DESCRIPTION
- Return error on receiving empty array for fdo_sys:exec, that is CBOR
value '80', instead of continuing with it and returning error later.
- Log the received RVDelaySec in RendezvousInfo and log the delays.
- Additionally, add a missed NULL check and few new-lines on logs.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>