### PR TITLE
Use 32/64 byte key as DCHMACSecret based on crypto strength

### DIFF
--- a/crypto/common/fdoHmac.c
+++ b/crypto/common/fdoHmac.c
@@ -30,7 +30,7 @@ int32_t set_ov_key(fdo_byte_array_t *OVkey, size_t OVKey_len)
 
 	if ((NULL == OVkey) || !(OVkey->bytes) ||
 	    !((BUFF_SIZE_32_BYTES == OVKey_len) ||
-	      (BUFF_SIZE_48_BYTES == OVKey_len))) {
+	      (BUFF_SIZE_64_BYTES == OVKey_len))) {
 		return -1;
 	}
 
@@ -219,7 +219,7 @@ int32_t fdo_generate_ov_hmac_key(void)
 		       " from TPM.\n");
 
 #else
-	fdo_byte_array_t *secret = fdo_byte_array_alloc(INITIAL_SECRET_BYTES);
+	fdo_byte_array_t *secret = fdo_byte_array_alloc(FDO_HMAC_KEY_LENGTH);
 
 	if (!secret) {
 		LOG(LOG_ERROR, "Out of memory for OV HMAC key\n");
@@ -227,8 +227,8 @@ int32_t fdo_generate_ov_hmac_key(void)
 	}
 
 	/* Generate HMAC key for calcuating it over Ownership header */
-	fdo_crypto_random_bytes(secret->bytes, INITIAL_SECRET_BYTES);
-	if (0 != set_ov_key(secret, INITIAL_SECRET_BYTES)) {
+	fdo_crypto_random_bytes(secret->bytes, FDO_HMAC_KEY_LENGTH);
+	if (0 != set_ov_key(secret, FDO_HMAC_KEY_LENGTH)) {
 		goto err;
 	}
 
@@ -264,7 +264,7 @@ int32_t fdo_generate_ov_replacement_hmac_key(void)
 		       " from TPM.\n");
 
 #else
-	fdo_byte_array_t *secret = fdo_byte_array_alloc(INITIAL_SECRET_BYTES);
+	fdo_byte_array_t *secret = fdo_byte_array_alloc(FDO_HMAC_KEY_LENGTH);
 
 	if (!secret) {
 		LOG(LOG_ERROR, "Out of memory for OV replacement HMAC key\n");
@@ -272,8 +272,8 @@ int32_t fdo_generate_ov_replacement_hmac_key(void)
 	}
 
 	/* Generate replacement HMAC key for calcuating it over Ownership header */
-	fdo_crypto_random_bytes(secret->bytes, INITIAL_SECRET_BYTES);
-	if (0 != set_ov_replacement_key(secret, INITIAL_SECRET_BYTES)) {
+	fdo_crypto_random_bytes(secret->bytes, FDO_HMAC_KEY_LENGTH);
+	if (0 != set_ov_replacement_key(secret, FDO_HMAC_KEY_LENGTH)) {
 		goto err;
 	}
 
@@ -312,7 +312,7 @@ int32_t fdo_commit_ov_replacement_hmac_key(void)
 		return false;
 	}
 
-	if (0 != set_ov_key(*secret, INITIAL_SECRET_BYTES)) {
+	if (0 != set_ov_key(*secret, FDO_HMAC_KEY_LENGTH)) {
 		LOG(LOG_ERROR, "Failed to commit OV replacement HMAC key\n");
 		return false;
 	}

--- a/crypto/common/fdoHmac.c
+++ b/crypto/common/fdoHmac.c
@@ -74,7 +74,7 @@ int32_t set_ov_replacement_key(fdo_byte_array_t *OVkey, size_t OVKey_len)
 
 	if ((NULL == OVkey) || !(OVkey->bytes) ||
 	    !((BUFF_SIZE_32_BYTES == OVKey_len) ||
-	      (BUFF_SIZE_48_BYTES == OVKey_len))) {
+	      (BUFF_SIZE_64_BYTES == OVKey_len))) {
 		return -1;
 	}
 

--- a/crypto/include/fdoCryptoCommons.h
+++ b/crypto/include/fdoCryptoCommons.h
@@ -28,6 +28,7 @@
 #define SEK_KEY_SIZE 16
 #define KEX "ECDH"
 #define FDO_SHA_DIGEST_SIZE_USED BUFF_SIZE_32_BYTES
+#define FDO_HMAC_KEY_LENGTH BUFF_SIZE_32_BYTES
 
 // Encryption/Decryption Algorithms: AES128
 #define AES_128_BIT
@@ -44,6 +45,7 @@
 #define SEK_KEY_SIZE 32
 #define KEX "ECDH384"
 #define FDO_SHA_DIGEST_SIZE_USED BUFF_SIZE_48_BYTES
+#define FDO_HMAC_KEY_LENGTH BUFF_SIZE_64_BYTES
 
 // Encryption/Decryption Algorithms: AES256
 #define AES_256_BIT

--- a/lib/credentials_from_file.c
+++ b/lib/credentials_from_file.c
@@ -163,7 +163,7 @@ bool write_secure_device_credentials(const char *dev_cred_file,
 	/**
 	 * Blob format: DeviceCredential.DCHmacSecret as bstr.
 	 */
-	fdow_byte_string(fdow, (*ovkey)->bytes, INITIAL_SECRET_BYTES);
+	fdow_byte_string(fdow, (*ovkey)->bytes, (*ovkey)->byte_sz);
 	size_t encoded_secret_length = 0;
 	if (!fdow_encoded_length(fdow, &encoded_secret_length) || encoded_secret_length == 0) {
 		LOG(LOG_ERROR, "Failed to get encoded DeviceCredential.DCHmacSecret length\n");
@@ -378,8 +378,7 @@ bool read_secure_device_credentials(const char *dev_cred_file,
 		goto end;
 	}
 
-	// TO-DO : Is it always 32 bytes? Could it be 48 bytes as well? Compare length.
-	secret = fdo_byte_array_alloc(INITIAL_SECRET_BYTES);
+	secret = fdo_byte_array_alloc(FDO_HMAC_KEY_LENGTH);
 	if (!secret) {
 		LOG(LOG_ERROR, "Dev_cred Secret malloc Failed.\n");
 		goto end;
@@ -390,7 +389,7 @@ bool read_secure_device_credentials(const char *dev_cred_file,
 		goto end;
 	}
 
-	if (0 != set_ov_key(secret, INITIAL_SECRET_BYTES)) {
+	if (0 != set_ov_key(secret, FDO_HMAC_KEY_LENGTH)) {
 		LOG(LOG_ERROR, "Failed to set HMAC secret.\n");
 		goto end;
 	}

--- a/lib/include/fdoprot.h
+++ b/lib/include/fdoprot.h
@@ -11,7 +11,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define INITIAL_SECRET_BYTES (32)
 #define GID_SIZE (16)
 
 // FDO Device States


### PR DESCRIPTION
- Use 32 byte key for HMAC-SHA256 and 64 byte key for HMAC-SHA384
operations for generation of Device HMAC for OwnershipVoucherHeader,
instead of using constant 32 byte key for both. This is done by updating
the DCHMACSecret to be of 32/64 bytes depending DA as ecdsa256/ecdsa384.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>