### PR TITLE
Updating Device ServiceInfo framework to handle writes

### DIFF
--- a/device_modules/fdo_sys/fdo_sys.h
+++ b/device_modules/fdo_sys/fdo_sys.h
@@ -23,13 +23,21 @@
 #define MOD_MAX_EXEC_ARG_LEN 100
 
 /**
- * The registered callback method for 'fdo_sys' Owner ServiceInfo module.
+ * The registered callback method for 'fdo_sys' ServiceInfo module.
+ * The implementation is responsible for handling the received Owner ServiceInfo,
+ * and for generating the Device ServiceInfo to send.
  * 
  * The input FDOR object holds the CBOR-encoded binary stream for the entire
  * decrypted messsage of TO2.OwnerServiceInfo (Type 69), with the current position
  * set to the ServiceInfoVal.
  * The implementation 'MUST' directly parse and process ServiceInfoVal 'ONLY' 
  * that's currently being pointed at, depending on the given module message, and return.
+ *
+ * The input FDOW object to be used to write the desired 'ServiceInfo' structure
+ * as per the specification, that will be sent to the Owner. The FDOW can also be used
+ * for other purposes such as ServiceInfo message partitioning (fit within MTU), or,
+ * determining has_more/is_more etc. The module implemenation is responsible for maintaining
+ * any internal state information, as needed.
  * 
  * The input fdo_sdk_si_type can be used to do specific tasks depending on the use-case.
  * However, it 'MUST' throw error on FDO_SI_GET_DSI.
@@ -37,9 +45,18 @@
  * 
  * @param type - enum value to describe the operation to be done.
  * @param fdor - FDOR object pointing to the ServiceInfoVal.
+ * @param fdow - FDOW object to use to write Device ServiceInfoVal(s)
  * @param module_message - moduleMessage that decides how ServiceInfoVal is processed.
+ * @param has_more - pointer to bool whose value must be set to
+ * 'true' if there is Device ServiceInfo to send NOW/immediately, OR,
+ * 'false' if there is no Device ServiceInfo to send NOW/immediately.
+ * @param is_more - pointer to bool whose value must be set to
+ * 'true' if there is Device ServiceInfo to send in the NEXT ietration, OR,
+ * 'false' if there is no Device ServiceInfo to send in the NEXT iteration.
+ * @param mtu - MTU value to be used as the upper bound for the ServiceInfo length.
  * @return integer value FDO_SI_CONTENT_ERROR (0), FDO_SI_INTERNAL_ERROR (1), FDO_SI_SUCCESS (2).
  */
-int fdo_sys(fdo_sdk_si_type type, fdor_t *fdor, char *module_message);
+int fdo_sys(fdo_sdk_si_type type, fdor_t *fdor, fdow_t *fdow,
+    char *module_message, bool *has_more, bool *is_more, size_t mtu);
 
 #endif /* __FDO_SYS_H__ */

--- a/include/fdomodules.h
+++ b/include/fdomodules.h
@@ -29,6 +29,8 @@
 // enum for Service_info Types
 typedef enum {
 	FDO_SI_START,
+	FDO_SI_HAS_MORE_DSI,
+	FDO_SI_IS_MORE_DSI,
 	FDO_SI_GET_DSI,
 	FDO_SI_SET_OSI,
 	FDO_SI_END,
@@ -44,17 +46,17 @@ typedef struct fdo_sdk_si_key_value {
 } fdo_sdk_si_key_value;
 
 // callback to module
-typedef int (*fdo_sdk_device_service_infoCB)(fdo_sdk_si_type type, fdow_t *fdow);
-typedef int (*fdo_sdk_owner_service_infoCB)(fdo_sdk_si_type type,
-	fdor_t *fdor, char *module_message);
+typedef int (*fdo_sdk_service_infoCB)(fdo_sdk_si_type type,
+	fdor_t *fdor, fdow_t *fdow, char *module_message, bool *has_more, bool *is_more, size_t mtu);
 
 /* module struct for modules */
 typedef struct {
 	bool active;
 	char module_name[FDO_MODULE_NAME_LEN];
-	fdo_sdk_owner_service_infoCB service_info_callback;
+	fdo_sdk_service_infoCB service_info_callback;
 } fdo_sdk_service_info_module;
 
-extern int fdo_sys(fdo_sdk_si_type type, fdor_t *fdor, char *module_message);
+extern int fdo_sys(fdo_sdk_si_type type, fdor_t *fdor, fdow_t *fdow,
+	char *module_message, bool *has_more, bool *is_more, size_t mtu);
 
 #endif /* __FDOTYPES_H__ */

--- a/lib/include/fdotypes.h
+++ b/lib/include/fdotypes.h
@@ -480,10 +480,6 @@ bool fdo_signature_verification(fdo_byte_array_t *plain_text,
 				fdo_byte_array_t *sg, fdo_public_key_t *pk);
 
 bool fdo_compare_public_keys(fdo_public_key_t *pk1, fdo_public_key_t *pk2);
-bool fdo_serviceinfo_write(fdow_t *fdow, fdo_service_info_t *si);
-bool fdo_serviceinfo_kv_write(fdow_t *fdow, fdo_service_info_t *si, size_t num);
-bool fdo_serviceinfo_modules_list_write(fdow_t *fdow);
-bool fdo_serviceinfo_fit_mtu(fdow_t *fdow, fdo_service_info_t *si, size_t mtu);
 
 /*==================================================================*/
 /* Service Info functionality */
@@ -507,6 +503,18 @@ typedef struct fdo_sv_info_dsi_info_s {
 void fdo_sdk_service_info_register_module(fdo_sdk_service_info_module *module);
 void fdo_sdk_service_info_deregister_module(void);
 void print_service_info_module_list(void);
+
+bool fdo_serviceinfo_write(fdow_t *fdow, fdo_service_info_t *si);
+bool fdo_serviceinfo_kv_write(fdow_t *fdow, fdo_service_info_t *si, size_t num);
+bool fdo_serviceinfo_modules_list_write(fdow_t *fdow);
+bool fdo_serviceinfo_external_mod_is_more(fdow_t *fdow,
+	fdo_sdk_service_info_module_list_t *module_list, size_t mtu);
+fdo_sdk_service_info_module* fdo_serviceinfo_get_external_mod_to_write(fdow_t *fdow,
+	fdo_sdk_service_info_module_list_t *module_list,
+	size_t mtu);
+bool fdo_serviceinfo_external_mod_write(fdow_t *fdow, fdo_sdk_service_info_module *module,
+	size_t mtu);
+bool fdo_serviceinfo_fit_mtu(fdow_t *fdow, fdo_service_info_t *si, size_t mtu);
 
 bool fdo_mod_exec_sv_infotype(fdo_sdk_service_info_module_list_t *module_list,
 			      fdo_sdk_si_type type);

--- a/lib/include/fdotypes.h
+++ b/lib/include/fdotypes.h
@@ -508,7 +508,7 @@ bool fdo_serviceinfo_write(fdow_t *fdow, fdo_service_info_t *si);
 bool fdo_serviceinfo_kv_write(fdow_t *fdow, fdo_service_info_t *si, size_t num);
 bool fdo_serviceinfo_modules_list_write(fdow_t *fdow);
 bool fdo_serviceinfo_external_mod_is_more(fdow_t *fdow,
-	fdo_sdk_service_info_module_list_t *module_list, size_t mtu);
+	fdo_sdk_service_info_module_list_t *module_list, size_t mtu, bool *is_more);
 fdo_sdk_service_info_module* fdo_serviceinfo_get_external_mod_to_write(fdow_t *fdow,
 	fdo_sdk_service_info_module_list_t *module_list,
 	size_t mtu);

--- a/lib/prot/to2/msg68.c
+++ b/lib/prot/to2/msg68.c
@@ -40,6 +40,9 @@ int32_t msg68(fdo_prot_t *ps)
 	fdo_sv_invalid_modnames_t *serviceinfo_invalid_modnames_it = NULL;
 	char sv_modname_key[FDO_MODULE_NAME_LEN + FDO_MODULE_MSG_LEN + 1] = "";
 	size_t serviceinfo_invalid_modnames_count = 0;
+	// Pointer to hold the external module reference. No memory is allocated, thus never freed.
+	fdo_sdk_service_info_module *ext_module = NULL;
+	bool module_write_done = false;
 
 	if (!ps) {
 		LOG(LOG_ERROR, "Invalid protocol state\n");
@@ -48,31 +51,33 @@ int32_t msg68(fdo_prot_t *ps)
 
 	LOG(LOG_DEBUG, "TO2.DeviceServiceInfo started\n");
 
-	// DeviceServiceInfo's that need to be sent:
-	// 1. 'devmod' module (1st iteration)
-	// 2. Response [modname:active,false] when an unsupported module is being accessed.
-	// 3. External module(s) (remaining iterations) TO-DO later
-	// when multiple modules support will be added
-	// The current implementation only handle (1) and (2).
+	/* send entry number to load */
+	fdow_next_block(&ps->fdow, FDO_TO2_GET_NEXT_OWNER_SERVICE_INFO);
 
-	// either ther is something to send (calulate ismore), or nothing to send (ismore=false)
-	if (!ps->service_info && !ps->serviceinfo_invalid_modnames) {
-		ps->device_serviceinfo_ismore = false;
-	} else {
+	// DeviceServiceInfo's that need to be sent, sequentially:
+	// 1. 'devmod' module contained within 'ps->service_info' will be sent by default initially.
+	// Once sent completely, 'ps->service_info' is cleared for further usage to send (2).
+	// 2. Response [modname:active, false] when an unsupported module is being accessed.
+	// Stored in 'ps->service_info', and once sent completely, is cleared for further usage.
+	// 3. External module(s) (remaining iterations, as per module responses)
+
+	// Process ServiceInfo to send for Options (1), (2) and (3),
+	// ONLY IF, TO2.OwnerServiceInfo.isMoreServiceInfo is false.
+	if (!ps->owner_serviceinfo_ismore) {
+
+		// Preparing to send (2), because (1) is sent
+		// (which is why 'ps->service_info' is now NULL, as mentioned above)
 		// There is a list of unsupported module names that need to be sent, AND,
-		// it has not been added to the serviceinfo list, AND,
-		// Owner has nothing more to send (for now), so that we only add once
-		if (!ps->service_info && ps->serviceinfo_invalid_modnames &&
-			!ps->owner_serviceinfo_ismore) {
+		// it has not been added to the serviceinfo list, that is currently NULL.
+		if (!ps->service_info && ps->serviceinfo_invalid_modnames) {
 			ps->service_info = fdo_service_info_alloc();
 			if(!ps->service_info) {
 				LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to alloc ServiceInfo\n");
-				return false;
+				goto err;
 			}
 
 			serviceinfo_invalid_modnames_it = ps->serviceinfo_invalid_modnames;
 			while (serviceinfo_invalid_modnames_it) {
-
 				// The message to be sent contains a list of unsupported module names
 				// with key/message 'active' and value 'false', something of the form
 				// [[modname1:active, false], [modname2:active, false]]...
@@ -108,94 +113,158 @@ int32_t msg68(fdo_prot_t *ps)
 			// clear it here immediately, so we don't use it back
 			fdo_serviceinfo_invalid_modname_free(ps->serviceinfo_invalid_modnames);
 			ps->serviceinfo_invalid_modnames = NULL;
+
 		}
 
-		// The splitting is done by considering an additional margin for CBOR encoding.
-		// The data is CBOR encoded twice. First time to find the what can be fit, and
-		// and second time to actually transmit the ServiceInfo.
-		// This is done in this way, since the underlying
-		// TinyCBOR library doesn't allow us to change the total number of entries
-		// in an array (ServiceInfoKeyVal, in this case), once it's set.
-		if (!fdo_serviceinfo_fit_mtu(&ps->fdow, ps->service_info,
-			ps->maxDeviceServiceInfoSz - SERVICEINFO_MTU_FIT_MARGIN)) {
-			LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to fit within MTU\n");
+		// get any external module that has some ServiceInfo to send 'NOW',
+		ext_module = fdo_serviceinfo_get_external_mod_to_write(&ps->fdow,
+					ps->sv_info_mod_list_head,
+					ps->maxDeviceServiceInfoSz - SERVICEINFO_MTU_FIT_MARGIN);
+		// reset FDOW because it may have been used by the above method
+		fdo_block_reset(&ps->fdow.b);
+		ps->fdor.b.block_size = ps->prot_buff_sz;
+		if (!fdow_encoder_init(&ps->fdow)) {
+			LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to initialize FDOW encoder\n");
 			goto err;
 		}
 
-		if (ps->service_info->sv_index_end == ps->service_info->numKV &&
-			ps->service_info->sv_val_index == 0) {
-			ps->device_serviceinfo_ismore = false;
-		} else if (ps->service_info->sv_index_end < ps->service_info->numKV) {
-			ps->device_serviceinfo_ismore = true;
-		} else {
-			LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Invalid state reached while processing "
-				"Device ServiceInfo\n");
-			goto err;			
+		// Finally, Send ServiceInfo in priority:
+		// 1. Send 'devmod' 1st , and then received unsupported modules-names as a part of 1st 'if'
+		// i.e, (1) then (2). Fit within MTU as needed.
+		// 2. Send external module's Device ServiceInfo (if present) in the 'else if', i.e (3)
+		if (ps->service_info) {
+
+			// Try to fit in MTU for either (1) or (2), at any given time.
+			// The splitting is done by considering an additional margin for CBOR encoding.
+			// The data is CBOR encoded twice. First time to find the what can be fit, and
+			// and second time to actually transmit the ServiceInfo.
+			// This is done in this way, since the underlying
+			// TinyCBOR library doesn't allow us to change the total number of entries
+			// in an array (ServiceInfoKeyVal, in this case), once it's set.
+			if (!fdo_serviceinfo_fit_mtu(&ps->fdow, ps->service_info,
+				ps->maxDeviceServiceInfoSz - SERVICEINFO_MTU_FIT_MARGIN)) {
+				LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to fit within MTU\n");
+				goto err;
+			}
+
+			if (ps->service_info->sv_index_end == ps->service_info->numKV &&
+				ps->service_info->sv_val_index == 0) {
+				ps->device_serviceinfo_ismore = false;
+			} else if (ps->service_info->sv_index_end < ps->service_info->numKV) {
+				ps->device_serviceinfo_ismore = true;
+			} else {
+				LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Invalid state reached while processing "
+					"Device ServiceInfo\n");
+				goto err;
+			}
+
+			// reset FDOW because it was used in this method, out of place
+			fdo_block_reset(&ps->fdow.b);
+			ps->fdor.b.block_size = ps->prot_buff_sz;
+			if (!fdow_encoder_init(&ps->fdow)) {
+				LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to initialize FDOW encoder\n");
+				goto err;
+			}
+
+			if (!fdow_start_array(&ps->fdow, 2)) {
+				LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to start array\n");
+				goto err;
+			}
+
+			if (!fdow_boolean(&ps->fdow, ps->device_serviceinfo_ismore || ext_module)) {
+				LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to write IsMoreServiceInfo\n");
+				goto err;
+			}
+
+			serviceinfo_itr = ps->service_info;
+			// Construct and write Device ServiceInfo
+			if (!fdo_serviceinfo_write(&ps->fdow, serviceinfo_itr)) {
+				LOG(LOG_ERROR, "Error in combining platform DSI's!\n");
+				goto err;
+			}
+
+			if (!fdow_end_array(&ps->fdow)) {
+				LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to end array\n");
+				goto err;
+			}
+
+			serviceinfo_itr = NULL;
+			// there is nothing to send, so clear it immediately
+			// so that we don't use it in the next iteration
+			if (!ps->device_serviceinfo_ismore) {
+				fdo_service_info_free(ps->service_info);
+				ps->service_info = NULL;
+			}
+			// if we reach here, ServiceInfo write has been done
+			module_write_done = true;
+
+		} else if (ext_module) {
+			// write External module ServiceInfo
+
+			ps->device_serviceinfo_ismore = fdo_serviceinfo_external_mod_is_more(&ps->fdow,
+				ps->sv_info_mod_list_head,
+				ps->maxDeviceServiceInfoSz - SERVICEINFO_MTU_FIT_MARGIN);
+			// reset FDOW because it may have been used by the above method
+			fdo_block_reset(&ps->fdow.b);
+			ps->fdor.b.block_size = ps->prot_buff_sz;
+			if (!fdow_encoder_init(&ps->fdow)) {
+				LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to initialize FDOW encoder\n");
+				goto err;
+			}
+
+			if (!fdow_start_array(&ps->fdow, 2)) {
+				LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to start array\n");
+				goto err;
+			}
+
+			if (!fdow_boolean(&ps->fdow, ps->device_serviceinfo_ismore)) {
+				LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to write IsMoreServiceInfo\n");
+				goto err;
+			}
+
+			if (!fdo_serviceinfo_external_mod_write(&ps->fdow, ext_module,
+				ps->maxDeviceServiceInfoSz - SERVICEINFO_MTU_FIT_MARGIN)) {
+				LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to write External module ServiceInfo\n");
+				goto err;
+			}
+
+			if (!fdow_end_array(&ps->fdow)) {
+				LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to end array\n");
+				goto err;
+			}
+			// if we reach here, ServiceInfo write has been done
+			module_write_done = true;
 		}
+
 	}
 
-	// reset FDOW because it was used in this method, out of place
-	fdo_block_reset(&ps->fdow.b);
-	ps->fdor.b.block_size = ps->prot_buff_sz;
-	if (!fdow_encoder_init(&ps->fdow)) {
-		LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to initialize FDOW encoder\n");
-		goto err;
-	}
-
-	/* send entry number to load */
-	fdow_next_block(&ps->fdow, FDO_TO2_GET_NEXT_OWNER_SERVICE_INFO);
-
-	if (!fdow_start_array(&ps->fdow, 2)) {
-		LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to start array\n");
-		return false;
-	}
-
-	// Send ServiceInfo only if:
-	// 1. We have ServiceInfo to send, AND
-	// 2. Owner has nothing more to send (for now atleast)
-	if (ps->service_info && !ps->owner_serviceinfo_ismore) {
-
-		if (!fdow_boolean(&ps->fdow, ps->device_serviceinfo_ismore)) {
-			LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to write IsMoreServiceInfo\n");
-			return false;
-		}
-
-		serviceinfo_itr = ps->service_info;
-		// Construct and write Device ServiceInfo
-		if (!fdo_serviceinfo_write(&ps->fdow, serviceinfo_itr)) {
-			LOG(LOG_ERROR, "Error in combining platform DSI's!\n");
-			goto err;
-		}
-
-		serviceinfo_itr = NULL;
-		// there is nothing to send, so clear it immediately
-		// so that we don't use it in the next iteration
-		if (!ps->device_serviceinfo_ismore) {
-			fdo_service_info_free(ps->service_info);
-			ps->service_info = NULL;
-		}
-
-	} else {
-
+	// write Empty ServiceInfo message if no write has been performed yet,
+	// OR if TO2.OwnerServiceInfo.isMoreServiceInfo is true
+	if (ps->owner_serviceinfo_ismore || !module_write_done) {
 		// Empty ServiceInfo. send [false, []]
+		if (!fdow_start_array(&ps->fdow, 2)) {
+			LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to start array\n");
+			goto err;
+		}
+
 		if (!fdow_boolean(&ps->fdow, ps->device_serviceinfo_ismore)) {
 			LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to write IsMoreServiceInfo\n");
-			return false;
+			goto err;
 		}
 
 		if (!fdow_start_array(&ps->fdow, 0)) {
 			LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to start empty ServiceInfo array\n");
-			return false;
+			goto err;
 		}
 		if (!fdow_end_array(&ps->fdow)) {
 			LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to end empty ServiceInfo array\n");
-			return false;
+			goto err;
 		}
-	}
 
-	if (!fdow_end_array(&ps->fdow)) {
-		LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to end array\n");
-		return false;
+		if (!fdow_end_array(&ps->fdow)) {
+			LOG(LOG_ERROR, "TO2.DeviceServiceInfo: Failed to end array\n");
+			goto err;
+		}
 	}
 
 	if (!fdo_encrypted_packet_windup(

--- a/lib/prot/to2/msg69.c
+++ b/lib/prot/to2/msg69.c
@@ -128,10 +128,10 @@ int32_t msg69(fdo_prot_t *ps)
 			goto err;
 		}
 		// Device does not have anything else to send
-		if (!ps->serviceinfo_invalid_modnames) {
+		if (!ps->serviceinfo_invalid_modnames && !ps->device_serviceinfo_ismore) {
 			ps->state = FDO_STATE_TO2_SND_DONE;
 		} else {
-			// Device has more ServiceInfo to send
+			// Device has more ServiceInfo to send (ONLY Unsupported module names can be sent)
 			ps->state = FDO_STATE_T02_SND_GET_NEXT_OWNER_SERVICE_INFO;
 		}
 	} else {


### PR DESCRIPTION
Updating Device ServiceInfo callback method to contain parameters for
handling write operations. Following parameters have been added:
- fdow: Writer to be used for writing ServiceInfo
- has_more: bool value that represents whether the module has some
ServiceInfo to send NOW/immediately (true) or not (false).
- is_more: bool value that represents whether the module has some
ServiceInfo to send in the NEXT iteration/message (true), or not
(false).
- mtu: Maximum length of the ServiceInfo that the module can append.
Module MUST use this information to fit the ServiceInfo to send across
messages by partitioning the same and keeping state information.

The ServiceInfo module implementor needs to maintain the necessary
states and implement functionalities for each 'fdo_sdk_si_type'.
Certain new addtions for the above mentioned operations are:
- FDO_SI_HAS_MORE_DSI: Update 'has_more'.
- FDO_SI_IS_MORE_DSI: Update 'is_more'.
- FDO_SI_GET_DSI: Write the ServiceInfo using/onto FDOW.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>