### PR TITLE
Fix: fdo_sys:exec_cb/exec not working after initial fdo_sys:exec

### DIFF
--- a/device_modules/fdo_sys/sys_utils_linux.c
+++ b/device_modules/fdo_sys/sys_utils_linux.c
@@ -214,6 +214,8 @@ bool process_data(fdoSysModMsg type, uint8_t *data, uint32_t data_len,
 #ifdef DEBUG_LOGS
 						printf("fdo_sys exec : Process execution completed.\n");
 #endif
+						// reset the process ID since execution is done
+						exec_pid = -1;
 						ret = true;
 						goto end;
 					}
@@ -276,6 +278,7 @@ bool process_data(fdoSysModMsg type, uint8_t *data, uint32_t data_len,
 #ifdef DEBUG_LOGS
 					printf("fdo_sys status_cb: Process execution completed\n");
 #endif
+					// reset the process ID since execution is done
 					exec_pid = -1;
 					ret = true;
 					goto end;


### PR DESCRIPTION
- Fixing an issue where the process ID was not being reset upon
fdo_sys:exec completion, leading to rejection/non-execution of subsequent
fdo_sys:exec/exec_cb commands.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>